### PR TITLE
BN-1645 Refactor statements and policies into datum #11

### DIFF
--- a/documentation/docs/reference/locks/build-lock.mdx
+++ b/documentation/docs/reference/locks/build-lock.mdx
@@ -40,7 +40,7 @@ import org.plasmalabs.sdk.builders.locks.LockTemplate.PredicateTemplate
 import org.plasmalabs.sdk.models.box.Lock
 import org.plasmalabs.sdk.syntax.cryptoToPbKeyPair
 import org.plasmalabs.crypto.signing.ExtendedEd25519
-import quivr.models.KeyPair
+import org.plasmalabs.quivr.models.KeyPair
 
 
 val signatureTemplate: PropositionTemplate[IO] = SignatureTemplate[IO]("ExtendedEd25519", 0)

--- a/documentation/docs/reference/locks/create-lock-addr.mdx
+++ b/documentation/docs/reference/locks/create-lock-addr.mdx
@@ -40,7 +40,7 @@ import org.plasmalabs.sdk.models.LockAddress
 import org.plasmalabs.sdk.models.box.Lock
 import org.plasmalabs.sdk.syntax.cryptoToPbKeyPair
 import org.plasmalabs.crypto.signing.ExtendedEd25519
-import quivr.models.KeyPair
+import org.plasmalabs.quivr.models.KeyPair
 
 
 val signatureTemplate: PropositionTemplate[IO] = SignatureTemplate[IO]("ExtendedEd25519", 0)

--- a/documentation/docs/reference/locks/share-lock-addr.mdx
+++ b/documentation/docs/reference/locks/share-lock-addr.mdx
@@ -63,7 +63,7 @@ import org.plasmalabs.sdk.models.box.Lock
 import org.plasmalabs.sdk.syntax.cryptoToPbKeyPair
 import org.plasmalabs.sdk.utils.EncodingError
 import org.plasmalabs.crypto.signing.ExtendedEd25519
-import quivr.models.KeyPair
+import org.plasmalabs.quivr.models.KeyPair
 
 
 val signatureTemplate: PropositionTemplate[IO] = SignatureTemplate[IO]("ExtendedEd25519", 0)

--- a/documentation/docs/reference/wallet-state.mdx
+++ b/documentation/docs/reference/wallet-state.mdx
@@ -143,7 +143,7 @@ import org.plasmalabs.sdk.models.Indices
 import org.plasmalabs.sdk.servicekit.{WalletKeyApi, WalletStateApi, WalletStateResource}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.WalletApi
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.io.File
 
@@ -204,7 +204,7 @@ import org.plasmalabs.sdk.servicekit.{WalletKeyApi, WalletStateApi, WalletStateR
 import org.plasmalabs.sdk.wallet.WalletApi
 import org.plasmalabs.crypto.hash.Blake2b256
 import com.google.protobuf.ByteString
-import quivr.models.{Digest, Preimage, Proposition}
+import org.plasmalabs.quivr.models.{Digest, Preimage, Proposition}
 
 import java.io.File
 

--- a/documentation/docs/service-kit/usage.md
+++ b/documentation/docs/service-kit/usage.md
@@ -113,7 +113,7 @@ import org.plasmalabs.sdk.builders.TransactionBuilderApi.implicits.lockAddressOp
 import co.topl.brambl.constants.NetworkConstants.{MAIN_LEDGER_ID, PRIVATE_NETWORK_ID}
 import org.plasmalabs.sdk.models.Indices
 import org.plasmalabs.sdk.utils.Encoding
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.io.File
 

--- a/documentation/docs/tutorials/tutorials/merge-asset.mdx
+++ b/documentation/docs/tutorials/tutorials/merge-asset.mdx
@@ -170,7 +170,7 @@ import org.plasmalabs.sdk.models.Indices
 import org.plasmalabs.sdk.syntax.{int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 
@@ -281,7 +281,7 @@ import org.plasmalabs.sdk.models.box.FungibilityType.GROUP
 import org.plasmalabs.sdk.syntax.{int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 
@@ -397,7 +397,7 @@ import org.plasmalabs.sdk.models.box.FungibilityType.GROUP
 import org.plasmalabs.sdk.syntax.{int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 
@@ -530,7 +530,7 @@ import org.plasmalabs.sdk.models.box.AssetMintingStatement
 import org.plasmalabs.sdk.syntax.{bigIntAsInt128, int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 
@@ -648,7 +648,7 @@ import org.plasmalabs.sdk.models.box.AssetMintingStatement
 import org.plasmalabs.sdk.syntax.{bigIntAsInt128, int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 
@@ -783,7 +783,7 @@ import org.plasmalabs.sdk.display.DisplayOps.DisplayTOps
 import org.plasmalabs.sdk.models.Indices
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.WalletApi
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 

--- a/documentation/docs/tutorials/tutorials/mint-asset.md
+++ b/documentation/docs/tutorials/tutorials/mint-asset.md
@@ -228,7 +228,7 @@ import org.plasmalabs.sdk.servicekit.{WalletKeyApi, WalletStateApi, WalletStateR
 import org.plasmalabs.sdk.syntax.{int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 
@@ -406,7 +406,7 @@ import org.plasmalabs.sdk.servicekit.{WalletKeyApi, WalletStateApi, WalletStateR
 import org.plasmalabs.sdk.syntax.{LvlType, int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 
@@ -597,7 +597,7 @@ import org.plasmalabs.sdk.servicekit.{WalletKeyApi, WalletStateApi, WalletStateR
 import org.plasmalabs.sdk.syntax.{bigIntAsInt128, int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 

--- a/documentation/docs/tutorials/tutorials/simple-transfer.md
+++ b/documentation/docs/tutorials/tutorials/simple-transfer.md
@@ -324,7 +324,7 @@ import org.plasmalabs.sdk.servicekit.{WalletKeyApi, WalletStateApi, WalletStateR
 import org.plasmalabs.sdk.syntax.LvlType
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.wallet.{CredentiallerInterpreter, WalletApi}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 
 import java.nio.file.Paths
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/Context.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/Context.scala
@@ -12,7 +12,7 @@ import org.plasmalabs.sdk.validation.{
   Sha256DigestInterpreter
 }
 import org.plasmalabs.common.ParsableDataInterface
-import quivr.models.SignableBytes
+import org.plasmalabs.quivr.models.SignableBytes
 import org.plasmalabs.quivr.algebras.{DigestVerifier, SignatureVerifier}
 import org.plasmalabs.quivr.runtime.DynamicContext
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/MergingOps.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/MergingOps.scala
@@ -22,7 +22,7 @@ import org.plasmalabs.crypto.hash.digest.Digest32
 import org.plasmalabs.crypto.hash.implicits.{digestDigest32, sha256Hash}
 import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Struct
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.sdk.models.box.Value.Asset
 
 import scala.language.implicitConversions

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/UserInputValidations.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/UserInputValidations.scala
@@ -3,7 +3,8 @@ package org.plasmalabs.sdk.builders
 import cats.data.{Chain, NonEmptyChain, Validated, ValidatedNec}
 import cats.implicits.{catsSyntaxEitherId, catsSyntaxValidatedIdBinCompat0, toFoldableOps}
 import org.plasmalabs.sdk.models.box.Value._
-import org.plasmalabs.sdk.models.box.{AssetMintingStatement, QuantityDescriptorType}
+import org.plasmalabs.sdk.models.box.QuantityDescriptorType
+import org.plasmalabs.sdk.models.AssetMintingStatement
 import org.plasmalabs.sdk.models.{LockAddress, SeriesId, TransactionOutputAddress}
 import org.plasmalabs.sdk.syntax.{
   int128AsBigInt,
@@ -17,7 +18,7 @@ import org.plasmalabs.sdk.syntax.{
   ValueTypeIdentifier
 }
 import org.plasmalabs.indexer.services.Txo
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.Int128
 
 import scala.util.{Failure, Success, Try}
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/locks/LockTemplate.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/locks/LockTemplate.scala
@@ -5,7 +5,7 @@ import LockTemplate.LockType
 import cats.Monad
 import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEitherId, toFlatMapOps}
 import org.plasmalabs.sdk.builders.locks.PropositionTemplate.ThresholdTemplate
-import quivr.models.{Proposition, VerificationKey}
+import org.plasmalabs.quivr.models.{Proposition, VerificationKey}
 import org.plasmalabs.sdk.models.box.Lock
 import org.plasmalabs.sdk.models.box.Challenge
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/locks/PropositionTemplate.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/builders/locks/PropositionTemplate.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.sdk.builders.locks
 
 import org.plasmalabs.sdk.builders.BuilderError
-import quivr.models.{Data, Digest, Proposition, VerificationKey}
+import org.plasmalabs.quivr.models.{Data, Digest, Proposition, VerificationKey}
 import PropositionTemplate.PropositionType
 import cats.implicits.{
   catsSyntaxApplicativeId,

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/codecs/PropositionTemplateCodecs.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/codecs/PropositionTemplateCodecs.scala
@@ -8,7 +8,7 @@ import org.plasmalabs.sdk.utils.Encoding.{decodeFromBase58, encodeToBase58}
 import com.google.protobuf.ByteString
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
-import quivr.models.{Data, Digest}
+import org.plasmalabs.quivr.models.{Data, Digest}
 
 object PropositionTemplateCodecs {
   def encodePropositionTemplate[F[_]: Monad](template: PropositionTemplate[F]): Json = template.asJson

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/common/ContainsEvidence.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/common/ContainsEvidence.scala
@@ -8,7 +8,7 @@ import org.plasmalabs.crypto.hash.implicits._
 import org.plasmalabs.crypto.hash.Blake2b
 import org.plasmalabs.crypto.hash.blake2b256
 import com.google.protobuf.ByteString
-import quivr.models.Digest
+import org.plasmalabs.quivr.models.Digest
 
 /**
  * Contains signable bytes and has methods to get evidence of those bytes in the form of a 32 or 64 byte hash.

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/common/ContainsImmutable.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/common/ContainsImmutable.scala
@@ -343,14 +343,6 @@ object ContainsImmutable {
     implicit val headerEventImmutable: ContainsImmutable[Event.Header] =
       event => event.height.immutable
 
-    implicit val iotxPoliciesImmutable: ContainsImmutable[Event.IoTransaction.Policies] =
-      p =>
-        p.groupPolicies.immutable ++
-        p.seriesPolicies.immutable ++
-        p.mintingStatements.immutable ++
-        p.mergingStatements.immutable ++
-        p.splittingStatements.immutable
-
     implicit val iotxEventImmutable: ContainsImmutable[Event.IoTransaction] =
       event =>
         event.schedule.immutable ++

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/common/ContainsSignable.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/common/ContainsSignable.scala
@@ -6,7 +6,7 @@ import org.plasmalabs.sdk.models.box.Attestation
 import org.plasmalabs.sdk.models.common.ImmutableBytes
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.transaction.SpentTransactionOutput
-import quivr.models._
+import org.plasmalabs.quivr.models._
 
 // Long -> longSignable -> longSignableEvidence -> longSignableEvidenceId
 // Long -> longSignable -> longSignableEvidence -> longSingableEvidenceSignable -> longSingableEvidenceSignableEvidence

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/dataApi/WalletStateAlgebra.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/dataApi/WalletStateAlgebra.scala
@@ -4,7 +4,7 @@ import cats.data.ValidatedNel
 import org.plasmalabs.sdk.builders.locks.LockTemplate
 import org.plasmalabs.sdk.models.Indices
 import org.plasmalabs.sdk.models.box.Lock
-import quivr.models.{KeyPair, Preimage, Proposition}
+import org.plasmalabs.quivr.models.{KeyPair, Preimage, Proposition}
 
 /**
  * Defines a data API for storing and retrieving wallet interaction.

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/AssetDisplayOps.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/AssetDisplayOps.scala
@@ -1,7 +1,8 @@
 package org.plasmalabs.sdk.display
 
 import org.plasmalabs.sdk.display.DisplayOps.DisplayTOps
-import org.plasmalabs.sdk.models.box.{AssetMergingStatement, AssetMintingStatement, Value}
+import org.plasmalabs.sdk.models.box.Value
+import org.plasmalabs.sdk.models.{AssetMergingStatement, AssetMintingStatement}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.syntax.int128AsBigInt
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/GroupDisplayOps.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/GroupDisplayOps.scala
@@ -1,18 +1,18 @@
 package org.plasmalabs.sdk.display
 
 import org.plasmalabs.sdk.display.DisplayOps.DisplayTOps
-import org.plasmalabs.sdk.models.{Datum, GroupId, SeriesId}
+import org.plasmalabs.sdk.models.{Datum, GroupId, GroupPolicy, SeriesId}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.models.box.Value
 
 trait GroupDisplayOps {
   implicit val groupIdDisplay: DisplayOps[GroupId] = (id: GroupId) => Encoding.encodeToHex(id.value.toByteArray())
 
-  implicit val groupPolicyDisplay: DisplayOps[Datum.GroupPolicy] = (gp: Datum.GroupPolicy) =>
+  implicit val groupPolicyDisplay: DisplayOps[GroupPolicy] = (gp: GroupPolicy) =>
     Seq(
-      padLabel("Label") + gp.event.label,
-      padLabel("Registration-Utxo") + gp.event.registrationUtxo.display,
-      padLabel("Fixed-Series") + displayFixedSeries(gp.event.fixedSeries)
+      padLabel("Label") + gp.label,
+      padLabel("Registration-Utxo") + gp.registrationUtxo.display,
+      padLabel("Fixed-Series") + displayFixedSeries(gp.fixedSeries)
     ).mkString("\n")
 
   implicit val groupDisplay: DisplayOps[Value.Group] = (group: Value.Group) =>

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/QuivrDisplayOps.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/QuivrDisplayOps.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.sdk.display
 
 import org.plasmalabs.sdk.utils.Encoding
-import quivr.models.{Proof, Proposition}
+import org.plasmalabs.quivr.models.{Proof, Proposition}
 
 trait QuivrDisplayOps {
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/SeriesDisplayOps.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/SeriesDisplayOps.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.sdk.display
 
 import org.plasmalabs.sdk.display.DisplayOps.DisplayTOps
-import org.plasmalabs.sdk.models.{Datum, SeriesId}
+import org.plasmalabs.sdk.models.{SeriesId, SeriesPolicy}
 import org.plasmalabs.sdk.models.box.{FungibilityType, QuantityDescriptorType}
 import org.plasmalabs.sdk.utils.Encoding
 import org.plasmalabs.sdk.models.box.Value
@@ -25,17 +25,17 @@ trait SeriesDisplayOps {
     case _ => throw new Exception("Unknown quantity descriptor type") // should not happen
   }
 
-  implicit val seriesPolicyDisplay: DisplayOps[Datum.SeriesPolicy] = (sp: Datum.SeriesPolicy) =>
+  implicit val seriesPolicyDisplay: DisplayOps[SeriesPolicy] = (sp: SeriesPolicy) =>
     Seq(
-      padLabel("Label") + sp.event.label,
-      padLabel("Registration-Utxo") + sp.event.registrationUtxo.display,
-      padLabel("Fungibility") + sp.event.fungibility.display,
-      padLabel("Quantity-Descriptor") + sp.event.quantityDescriptor.display,
-      padLabel("Token-Supply") + displayTokenSupply(sp.event.tokenSupply),
+      padLabel("Label") + sp.label,
+      padLabel("Registration-Utxo") + sp.registrationUtxo.display,
+      padLabel("Fungibility") + sp.fungibility.display,
+      padLabel("Quantity-Descriptor") + sp.quantityDescriptor.display,
+      padLabel("Token-Supply") + displayTokenSupply(sp.tokenSupply),
       padLabel("Permanent-Metadata-Scheme"),
-      sp.event.permanentMetadataScheme.map(meta => meta.display).getOrElse("No permanent metadata"),
+      sp.permanentMetadataScheme.map(meta => meta.display).getOrElse("No permanent metadata"),
       padLabel("Ephemeral-Metadata-Scheme"),
-      sp.event.ephemeralMetadataScheme.map(meta => meta.display).getOrElse("No ephemeral metadata")
+      sp.ephemeralMetadataScheme.map(meta => meta.display).getOrElse("No ephemeral metadata")
     ).mkString("\n")
 
   implicit val seriesDisplay: DisplayOps[Value.Series] = (series: Value.Series) =>

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/TransactionDisplayOps.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/TransactionDisplayOps.scala
@@ -17,19 +17,19 @@ ${padLabel("TransactionId")}${tx.transactionId.getOrElse(tx.computeId).display}
 
 Group Policies
 ==============
-${tx.groupPolicies.map(gp => gp.display).mkString("\n-----------\n")}
+${tx.datum.event.policies.groupPolicies.map(gp => gp.display).mkString("\n-----------\n")}
 
 Series Policies
 ===============
-${tx.seriesPolicies.map(sp => sp.display).mkString("\n-----------\n")}
+${tx.datum.event.policies.seriesPolicies.map(sp => sp.display).mkString("\n-----------\n")}
 
 Asset Minting Statements
 ========================
-${tx.mintingStatements.map(ams => ams.display).mkString("\n-----------\n")}
+${tx.datum.event.policies.mintingStatements.map(ams => ams.display).mkString("\n-----------\n")}
 
 Asset Merging Statements
 ========================
-${tx.mergingStatements.map(ams => ams.display).mkString("\n-----------\n")}
+${tx.datum.event.policies.mergingStatements.map(ams => ams.display).mkString("\n-----------\n")}
 
 Inputs
 ======

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/TransactionDisplayOps.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/display/TransactionDisplayOps.scala
@@ -9,7 +9,7 @@ import org.plasmalabs.sdk.utils.Encoding
 trait TransactionDisplayOps {
 
   implicit val transactionIdDisplay: DisplayOps[TransactionId] = (id: TransactionId) =>
-    Encoding.encodeToBase58(id.value.toByteArray())
+    Encoding.encodeToBase58(id.value.toByteArray)
 
   implicit val transactionDisplay: DisplayOps[IoTransaction] = (tx: IoTransaction) =>
     s"""
@@ -17,19 +17,19 @@ ${padLabel("TransactionId")}${tx.transactionId.getOrElse(tx.computeId).display}
 
 Group Policies
 ==============
-${tx.datum.event.policies.groupPolicies.map(gp => gp.display).mkString("\n-----------\n")}
+${tx.datum.event.groupPolicies.map(gp => gp.display).mkString("\n-----------\n")}
 
 Series Policies
 ===============
-${tx.datum.event.policies.seriesPolicies.map(sp => sp.display).mkString("\n-----------\n")}
+${tx.datum.event.seriesPolicies.map(sp => sp.display).mkString("\n-----------\n")}
 
 Asset Minting Statements
 ========================
-${tx.datum.event.policies.mintingStatements.map(ams => ams.display).mkString("\n-----------\n")}
+${tx.datum.event.mintingStatements.map(ams => ams.display).mkString("\n-----------\n")}
 
 Asset Merging Statements
 ========================
-${tx.datum.event.policies.mergingStatements.map(ams => ams.display).mkString("\n-----------\n")}
+${tx.datum.event.mergingStatements.map(ams => ams.display).mkString("\n-----------\n")}
 
 Inputs
 ======
@@ -43,6 +43,6 @@ ${if (tx.outputs.isEmpty) ("No outputs")
 
 Datum
 =====
-${padLabel("Value")}${Encoding.encodeToBase58(tx.datum.event.metadata.value.toByteArray())}
+${padLabel("Value")}${Encoding.encodeToBase58(tx.datum.event.metadata.value.toByteArray)}
 """
 }

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/BoxValueSyntax.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/BoxValueSyntax.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.sdk.syntax
 
 import org.plasmalabs.sdk.models.box.{FungibilityType, QuantityDescriptorType}
 import org.plasmalabs.sdk.models.box.Value._
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.Int128
 
 import scala.language.implicitConversions
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/GroupPolicySyntax.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/GroupPolicySyntax.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.sdk.syntax
 
 import org.plasmalabs.sdk.common.ContainsImmutable.ContainsImmutableTOps
-import org.plasmalabs.sdk.common.ContainsImmutable.instances.groupPolicyEventImmutable
-import org.plasmalabs.sdk.models.Event.GroupPolicy
+import org.plasmalabs.sdk.common.ContainsImmutable.instances.groupPolicyImmutable
+import org.plasmalabs.sdk.models.GroupPolicy
 import org.plasmalabs.sdk.models.GroupId
 import com.google.protobuf.ByteString
 import java.security.MessageDigest

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/Int128Syntax.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/Int128Syntax.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.sdk.syntax
 
 import com.google.protobuf.ByteString
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.Int128
 
 import scala.language.implicitConversions
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/KeyPairSyntax.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/KeyPairSyntax.scala
@@ -3,9 +3,9 @@ package org.plasmalabs.sdk.syntax
 import org.plasmalabs.crypto.signing
 import org.plasmalabs.crypto.signing.ExtendedEd25519
 import com.google.protobuf.ByteString
-import quivr.models.SigningKey.ExtendedEd25519Sk
-import quivr.models.VerificationKey.{Ed25519Vk, ExtendedEd25519Vk}
-import quivr.models.{KeyPair, SigningKey, VerificationKey}
+import org.plasmalabs.quivr.models.SigningKey.ExtendedEd25519Sk
+import org.plasmalabs.quivr.models.VerificationKey.{Ed25519Vk, ExtendedEd25519Vk}
+import org.plasmalabs.quivr.models.{KeyPair, SigningKey, VerificationKey}
 
 import scala.language.implicitConversions
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/SeriesPolicySyntax.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/syntax/SeriesPolicySyntax.scala
@@ -1,8 +1,8 @@
 package org.plasmalabs.sdk.syntax
 
 import org.plasmalabs.sdk.common.ContainsImmutable.ContainsImmutableTOps
-import org.plasmalabs.sdk.common.ContainsImmutable.instances.seriesPolicyEventImmutable
-import org.plasmalabs.sdk.models.Event.SeriesPolicy
+import org.plasmalabs.sdk.common.ContainsImmutable.instances.seriesPolicyImmutable
+import org.plasmalabs.sdk.models.SeriesPolicy
 import org.plasmalabs.sdk.models.SeriesId
 import com.google.protobuf.ByteString
 import java.security.MessageDigest

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/utils/Encoding.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/utils/Encoding.scala
@@ -5,7 +5,7 @@ import scala.util.Success
 import scala.util.Try
 import org.plasmalabs.crypto.hash.sha256
 
-sealed abstract trait EncodingError extends Exception
+sealed trait EncodingError extends Exception
 case object InvalidChecksum extends EncodingError
 case object InvalidInputString extends EncodingError
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/Blake2b256DigestInterpreter.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/Blake2b256DigestInterpreter.scala
@@ -4,7 +4,7 @@ import cats.Monad
 import org.plasmalabs.quivr.algebras.DigestVerifier
 import org.plasmalabs.quivr.runtime.QuivrRuntimeError
 import org.plasmalabs.quivr.runtime.QuivrRuntimeErrors.ValidationError
-import quivr.models.{Digest, DigestVerification, Preimage}
+import org.plasmalabs.quivr.models.{Digest, DigestVerification, Preimage}
 import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEitherObject}
 import org.plasmalabs.crypto.hash.Blake2b256
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/ExtendedEd25519SignatureInterpreter.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/ExtendedEd25519SignatureInterpreter.scala
@@ -5,8 +5,8 @@ import cats.Monad
 import org.plasmalabs.quivr.algebras.SignatureVerifier
 import org.plasmalabs.quivr.runtime.QuivrRuntimeError
 import org.plasmalabs.quivr.runtime.QuivrRuntimeErrors.ValidationError
-import quivr.models.{Message, SignatureVerification, VerificationKey, Witness}
-import quivr.models.VerificationKey._
+import org.plasmalabs.quivr.models.{Message, SignatureVerification, VerificationKey, Witness}
+import org.plasmalabs.quivr.models.VerificationKey._
 import org.plasmalabs.crypto.signing.{Ed25519, ExtendedEd25519}
 
 /**

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/Sha256DigestInterpreter.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/Sha256DigestInterpreter.scala
@@ -9,7 +9,7 @@ import org.plasmalabs.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
   LockedPropositionIsUnsatisfiable,
   UserProvidedInterfaceFailure
 }
-import quivr.models.{Digest, DigestVerification, Preimage}
+import org.plasmalabs.quivr.models.{Digest, DigestVerification, Preimage}
 
 /**
  * Validates that a Sha256 digest is valid.

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionAuthorizationInterpreter.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionAuthorizationInterpreter.scala
@@ -6,7 +6,7 @@ import org.plasmalabs.sdk.models.{AccumulatorRootId, Datum, LockId}
 import org.plasmalabs.sdk.models.box.Attestation
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.validation.algebras.TransactionAuthorizationVerifier
-import quivr.models.{Proof, Proposition}
+import org.plasmalabs.quivr.models.{Proof, Proposition}
 import org.plasmalabs.quivr.api.Verifier
 import org.plasmalabs.quivr.runtime.DynamicContext
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionCostCalculatorInterpreter.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionCostCalculatorInterpreter.scala
@@ -5,7 +5,7 @@ import org.plasmalabs.sdk.common.ContainsImmutable.instances.ioTransactionImmuta
 import org.plasmalabs.sdk.models.box.Attestation
 import org.plasmalabs.sdk.models.transaction._
 import org.plasmalabs.sdk.validation.algebras.TransactionCostCalculator
-import quivr.models.Proof
+import org.plasmalabs.quivr.models.Proof
 
 object TransactionCostCalculatorInterpreter {
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionSyntaxError.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionSyntaxError.scala
@@ -1,9 +1,10 @@
 package org.plasmalabs.sdk.validation
 
 import org.plasmalabs.sdk.models.TransactionOutputAddress
-import org.plasmalabs.sdk.models.box.{AssetMergingStatement, Value}
+import org.plasmalabs.sdk.models.box.Value
+import org.plasmalabs.sdk.models.AssetMergingStatement
 import org.plasmalabs.sdk.models.transaction.Schedule
-import quivr.models.{Proof, Proposition}
+import org.plasmalabs.quivr.models.{Proof, Proposition}
 
 sealed abstract class TransactionSyntaxError extends ValidationError
 

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreter.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreter.scala
@@ -6,13 +6,12 @@ import cats.implicits._
 import org.plasmalabs.sdk.builders.MergingOps
 import org.plasmalabs.sdk.common.ContainsImmutable.ContainsImmutableTOps
 import org.plasmalabs.sdk.common.ContainsImmutable.instances._
-import org.plasmalabs.sdk.models.TransactionOutputAddress
+import org.plasmalabs.sdk.models.{AssetMergingStatement, AssetMintingStatement, TransactionOutputAddress}
 import org.plasmalabs.sdk.models.box._
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.syntax._
 import org.plasmalabs.sdk.validation.algebras.TransactionSyntaxVerifier
-import quivr.models.{Int128, Proof, Proposition}
-
+import org.plasmalabs.quivr.models.{Int128, Proof, Proposition}
 import scala.util.Try
 
 object TransactionSyntaxInterpreter {
@@ -252,12 +251,14 @@ object TransactionSyntaxInterpreter {
   private def assetEqualFundsValidation(transaction: IoTransaction): ValidatedNec[TransactionSyntaxError, Unit] = {
     val inputAssets = transaction.inputs
       .filterNot(in =>
-        transaction.mergingStatements.flatMap(_.inputUtxos).contains(in.address)
+        transaction.datum.event.policies.mergingStatements.flatMap(_.inputUtxos).contains(in.address)
       ) // ignoring merging inputs
       .filter(_.value.value.isAsset)
       .map(_.value.value)
     val outputAssets = transaction.outputs.zipWithIndex
-      .filterNot(out => transaction.mergingStatements.map(_.outputIdx).contains(out._2)) // ignoring merged outputs
+      .filterNot(out =>
+        transaction.datum.event.policies.mergingStatements.map(_.outputIdx).contains(out._2)
+      ) // ignoring merged outputs
       .map(_._1)
       .filter(_.value.value.isAsset)
       .map(_.value.value)
@@ -276,7 +277,7 @@ object TransactionSyntaxInterpreter {
         .map(_.value.getSeries)
         .headOption
 
-    val mintedAsset = transaction.mintingStatements.map { stm =>
+    val mintedAsset = transaction.datum.event.policies.mintingStatements.map { stm =>
       val series = seriesGivenMintedStatements(stm)
       Value.defaultInstance
         .withAsset(
@@ -344,10 +345,10 @@ object TransactionSyntaxInterpreter {
     val gIds =
       groupsIn.groupBy(_.groupId).keySet ++
       groupsOut.groupBy(_.groupId).keySet ++
-      transaction.groupPolicies.map(_.event.computeId).toSet
+      transaction.datum.event.policies.groupPolicies.map(_.computeId).toSet
 
     val res = gIds.forall { gId =>
-      if (!transaction.groupPolicies.map(_.event.computeId).contains(gId)) {
+      if (!transaction.datum.event.policies.groupPolicies.map(_.computeId).contains(gId)) {
         groupsIn.filter(_.groupId == gId).map(_.quantity: BigInt).sum ==
           groupsOut.filter(_.groupId == gId).map(_.quantity: BigInt).sum
       } else {
@@ -386,10 +387,10 @@ object TransactionSyntaxInterpreter {
     val sIds =
       seriesIn.groupBy(_.seriesId).keySet ++
       seriesOut.groupBy(_.seriesId).keySet ++
-      transaction.seriesPolicies.map(_.event.computeId).toSet
+      transaction.datum.event.policies.seriesPolicies.map(_.computeId).toSet
 
     val sIdsOnMintingStatements = {
-      val sIdsAddress = transaction.mintingStatements.map(_.seriesTokenUtxo)
+      val sIdsAddress = transaction.datum.event.policies.mintingStatements.map(_.seriesTokenUtxo)
       transaction.inputs
         .filter(sto => sIdsAddress.contains(sto.address))
         .filter(_.value.value.isSeries)
@@ -399,7 +400,7 @@ object TransactionSyntaxInterpreter {
     val res = sIds.forall { sId =>
       if (sIdsOnMintingStatements.contains(sId)) {
         seriesOut.filter(_.seriesId == sId).map(_.quantity: BigInt).sum >= 0
-      } else if (!transaction.seriesPolicies.map(_.event.computeId).contains(sId)) {
+      } else if (!transaction.datum.event.policies.seriesPolicies.map(_.computeId).contains(sId)) {
         seriesIn.filter(_.seriesId == sId).map(_.quantity: BigInt).sum ==
           seriesOut.filter(_.seriesId == sId).map(_.quantity: BigInt).sum
       } else {
@@ -429,7 +430,7 @@ object TransactionSyntaxInterpreter {
   private def assetNoRepeatedUtxosValidation(transaction: IoTransaction): ValidatedNec[TransactionSyntaxError, Unit] =
     NonEmptyChain
       .fromSeq {
-        val mintingStatementsValidation = transaction.mintingStatements
+        val mintingStatementsValidation = transaction.datum.event.policies.mintingStatements
           .flatMap(stm => Seq(stm.groupTokenUtxo, stm.seriesTokenUtxo))
           .groupBy(identity)
           .collect {
@@ -439,8 +440,10 @@ object TransactionSyntaxInterpreter {
           .toSeq
 
         val policiesValidation =
-          (transaction.groupPolicies.map(_.event.registrationUtxo) ++ transaction.seriesPolicies
-            .map(_.event.registrationUtxo))
+          (transaction.datum.event.policies.groupPolicies.map(
+            _.registrationUtxo
+          ) ++ transaction.datum.event.policies.seriesPolicies
+            .map(_.registrationUtxo))
             .groupBy(identity)
             .collect {
               case (address, seqAddresses) if seqAddresses.size > 1 =>
@@ -456,32 +459,32 @@ object TransactionSyntaxInterpreter {
     transaction.inputs.filter { stxo =>
       !stxo.value.value.isTopl &&
       !stxo.value.value.isAsset &&
-      (!stxo.value.value.isLvl || (transaction.groupPolicies.exists(
-        _.event.registrationUtxo == stxo.address
-      ) || transaction.seriesPolicies.exists(_.event.registrationUtxo == stxo.address)))
+      (!stxo.value.value.isLvl || (transaction.datum.event.policies.groupPolicies.exists(
+        _.registrationUtxo == stxo.address
+      ) || transaction.datum.event.policies.seriesPolicies.exists(_.registrationUtxo == stxo.address)))
     }
 
   private def mintingOutputsProjection(transaction: IoTransaction): Seq[UnspentTransactionOutput] = {
     val groupIdsOnMintedStatements =
       transaction.inputs
         .filter(_.value.value.isGroup)
-        .filter(sto => transaction.mintingStatements.map(_.groupTokenUtxo).contains(sto.address))
+        .filter(sto => transaction.datum.event.policies.mintingStatements.map(_.groupTokenUtxo).contains(sto.address))
         .map(_.value.getGroup.groupId)
 
     val seriesIdsOnMintedStatements =
       transaction.inputs
         .filter(_.value.value.isSeries)
-        .filter(sto => transaction.mintingStatements.map(_.seriesTokenUtxo).contains(sto.address))
+        .filter(sto => transaction.datum.event.policies.mintingStatements.map(_.seriesTokenUtxo).contains(sto.address))
         .map(_.value.getSeries.seriesId)
 
     transaction.outputs.filter { utxo =>
       !utxo.value.value.isLvl &&
       !utxo.value.value.isTopl &&
-      (!utxo.value.value.isGroup || transaction.groupPolicies
-        .map(_.event.computeId)
+      (!utxo.value.value.isGroup || transaction.datum.event.policies.groupPolicies
+        .map(_.computeId)
         .contains(utxo.value.getGroup.groupId)) &&
-      (!utxo.value.value.isSeries || transaction.seriesPolicies
-        .map(_.event.computeId)
+      (!utxo.value.value.isSeries || transaction.datum.event.policies.seriesPolicies
+        .map(_.computeId)
         .contains(utxo.value.getSeries.seriesId)) &&
       (!utxo.value.value.isAsset || (utxo.value.getAsset.groupId.exists(
         groupIdsOnMintedStatements.contains
@@ -505,17 +508,17 @@ object TransactionSyntaxInterpreter {
       }
 
     val validGroups = groups.forall { group =>
-      transaction.groupPolicies.exists { policy =>
-        policy.event.computeId == group.groupId &&
-        registrationInPolicyContainsLvls(policy.event.registrationUtxo)
+      transaction.datum.event.policies.groupPolicies.exists { policy =>
+        policy.computeId == group.groupId &&
+        registrationInPolicyContainsLvls(policy.registrationUtxo)
       } &&
       group.quantity > 0
     }
 
     val validSeries = series.forall { series =>
-      transaction.seriesPolicies.exists { policy =>
-        policy.event.computeId == series.seriesId &&
-        registrationInPolicyContainsLvls(policy.event.registrationUtxo) &&
+      transaction.datum.event.policies.seriesPolicies.exists { policy =>
+        policy.computeId == series.seriesId &&
+        registrationInPolicyContainsLvls(policy.registrationUtxo) &&
         series.quantity > 0
       }
     }
@@ -526,7 +529,7 @@ object TransactionSyntaxInterpreter {
      * and burned the number of where the referenced series specifies a token supply, then we have:
      * sIn - burned = sOut
      */
-    val validAssets = transaction.mintingStatements.forall { ams =>
+    val validAssets = transaction.datum.event.policies.mintingStatements.forall { ams =>
       val maybeSeries: Option[Value.Series] =
         transaction.inputs
           .filter(_.value.value.isSeries)
@@ -554,7 +557,7 @@ object TransactionSyntaxInterpreter {
               val burned = sIn - sOut
 
               // all asset minting statements quantity with the same series id
-              def quantity(s: Value.Series) = transaction.mintingStatements.map { ams =>
+              def quantity(s: Value.Series) = transaction.datum.event.policies.mintingStatements.map { ams =>
                 val filterSeries = transaction.inputs
                   .filter(_.address == ams.seriesTokenUtxo)
                   .filter(_.value.value.isSeries)
@@ -608,7 +611,7 @@ object TransactionSyntaxInterpreter {
    * Validate that the merging inputs are distinct (not re-used in other merging statements)
    */
   private def mergingDistinctValidation(transaction: IoTransaction): ValidatedNec[TransactionSyntaxError, Unit] = {
-    val mergingInputs = transaction.mergingStatements.flatMap(
+    val mergingInputs = transaction.datum.event.policies.mergingStatements.flatMap(
       _.inputUtxos.distinct
     ) // distinct within each merging statement since those duplicates are handled via InvalidMergingStatement
     val repeatedInputs: Seq[TransactionSyntaxError] = mergingInputs
@@ -641,7 +644,7 @@ object TransactionSyntaxInterpreter {
     def isValidStatement: AsmCheck = s =>
       Seq(outputIdxInBounds, multipleInputs, allInputsPresent, distinctInputs).forall(_(s))
 
-    val invalidMergingStatements = transaction.mergingStatements.filterNot(isValidStatement)
+    val invalidMergingStatements = transaction.datum.event.policies.mergingStatements.filterNot(isValidStatement)
     NonEmptyChain.fromSeq(invalidMergingStatements.map(TransactionSyntaxError.InvalidMergingStatement.apply)) match {
       case Some(repeated) => Validated.Invalid(repeated)
       case None           => ().validNec[TransactionSyntaxError]
@@ -690,7 +693,7 @@ object TransactionSyntaxInterpreter {
         validFungibility
       ).forall(_(v))
 
-    val toMerge = transaction.mergingStatements.map(asm =>
+    val toMerge = transaction.datum.event.policies.mergingStatements.map(asm =>
       MergingValues(
         asm.inputUtxos.map(input => transaction.inputs.find(_.address == input).get.value),
         transaction.outputs(asm.outputIdx).value

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/wallet/CredentiallerInterpreter.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/wallet/CredentiallerInterpreter.scala
@@ -14,7 +14,7 @@ import org.plasmalabs.sdk.common.ContainsSignable.ContainsSignableTOps
 import org.plasmalabs.sdk.common.ContainsSignable.instances._
 import org.plasmalabs.quivr.api.Prover
 import org.plasmalabs.quivr.api.Verifier.instances.verifierInstance
-import quivr.models.{KeyPair, Proof, Proposition, SignableBytes, Witness}
+import org.plasmalabs.quivr.models.{KeyPair, Proof, Proposition, SignableBytes, Witness}
 import org.plasmalabs.sdk.models.Indices
 import cats.data.EitherT
 import org.plasmalabs.sdk.dataApi.WalletStateAlgebra

--- a/plasma-sdk/src/main/scala/org/plasmalabs/sdk/wallet/WalletApi.scala
+++ b/plasma-sdk/src/main/scala/org/plasmalabs/sdk/wallet/WalletApi.scala
@@ -11,7 +11,7 @@ import org.plasmalabs.crypto.encryption.kdf.SCrypt
 import org.plasmalabs.crypto.encryption.cipher.Cipher
 import org.plasmalabs.crypto.encryption.cipher.Aes
 import org.plasmalabs.crypto.signing.ExtendedEd25519
-import quivr.models._
+import org.plasmalabs.quivr.models._
 import org.plasmalabs.sdk.syntax.{cryptoToPbKeyPair, cryptoVkToPbVk, pbKeyPairToCryptoKeyPair, pbVkToCryptoVk}
 import cats.implicits._
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/MockHelpers.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/MockHelpers.scala
@@ -8,7 +8,7 @@ import org.plasmalabs.sdk.common.ContainsImmutable.ContainsImmutableTOps
 import org.plasmalabs.sdk.common.ContainsImmutable.instances._
 import org.plasmalabs.sdk.common.ContainsSignable.ContainsSignableTOps
 import org.plasmalabs.sdk.common.ContainsSignable.instances._
-import org.plasmalabs.sdk.models.Event.{GroupPolicy, SeriesPolicy}
+import org.plasmalabs.sdk.models.{GroupPolicy, SeriesPolicy}
 import org.plasmalabs.sdk.models._
 import org.plasmalabs.sdk.models.box.Attestation
 import org.plasmalabs.sdk.models.box.Challenge
@@ -21,7 +21,7 @@ import org.plasmalabs.sdk.syntax.{assetAsBoxVal, groupPolicyAsGroupPolicySyntaxO
 import org.plasmalabs.quivr.api.Proposer
 import org.plasmalabs.quivr.api.Prover
 import com.google.protobuf.ByteString
-import quivr.models.{
+import org.plasmalabs.quivr.models.{
   Digest,
   Int128,
   KeyPair,
@@ -100,7 +100,8 @@ trait MockHelpers {
     Event
       .IoTransaction(
         Schedule(0, Long.MaxValue, System.currentTimeMillis),
-        SmallData.defaultInstance
+        SmallData.defaultInstance,
+        Event.IoTransaction.Policies()
       )
   )
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/MockHelpers.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/MockHelpers.scala
@@ -100,8 +100,7 @@ trait MockHelpers {
     Event
       .IoTransaction(
         Schedule(0, Long.MaxValue, System.currentTimeMillis),
-        SmallData.defaultInstance,
-        Event.IoTransaction.Policies()
+        SmallData.defaultInstance
       )
   )
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/MockWalletStateApi.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/MockWalletStateApi.scala
@@ -8,7 +8,7 @@ import org.plasmalabs.sdk.common.ContainsImmutable.instances._
 import org.plasmalabs.sdk.dataApi.WalletStateAlgebra
 import org.plasmalabs.sdk.models._
 import org.plasmalabs.sdk.models.box.Lock
-import quivr.models._
+import org.plasmalabs.quivr.models._
 
 /**
  * Mock Implementation of the WalletStateAlgebra for testing

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/BasicTransactionBuilderInterpreterSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/BasicTransactionBuilderInterpreterSpec.scala
@@ -1,5 +1,6 @@
 package org.plasmalabs.sdk.builders
 
+import org.plasmalabs.sdk.models.Event
 import org.plasmalabs.sdk.models.box.FungibilityType.GROUP_AND_SERIES
 import org.plasmalabs.sdk.models.box.QuantityDescriptorType.LIQUID
 import org.plasmalabs.sdk.models.box.Value
@@ -60,7 +61,7 @@ class BasicTransactionBuilderInterpreterSpec extends TransactionBuilderInterpret
   }
 
   test("datum") {
-    val testDatum = txBuilder.datum()
+    val testDatum = txBuilder.datum(Event.IoTransaction.Policies())
     // Testing fields individually since the timestamp is generated at runtime
     assert(testDatum.event.metadata == txDatum.event.metadata)
     assert(testDatum.event.schedule.min == txDatum.event.schedule.min)

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/BasicTransactionBuilderInterpreterSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/BasicTransactionBuilderInterpreterSpec.scala
@@ -61,7 +61,7 @@ class BasicTransactionBuilderInterpreterSpec extends TransactionBuilderInterpret
   }
 
   test("datum") {
-    val testDatum = txBuilder.datum(Event.IoTransaction.Policies())
+    val testDatum = txBuilder.datum()
     // Testing fields individually since the timestamp is generated at runtime
     assert(testDatum.event.metadata == txDatum.event.metadata)
     assert(testDatum.event.schedule.min == txDatum.event.schedule.min)

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
@@ -2,12 +2,14 @@ package org.plasmalabs.sdk.builders
 
 import org.plasmalabs.sdk.models.box.FungibilityType.GROUP
 import org.plasmalabs.sdk.models.box.QuantityDescriptorType.LIQUID
-import org.plasmalabs.sdk.models.box.{AssetMergingStatement, Value}
-import org.plasmalabs.sdk.models.transaction.IoTransaction
+import org.plasmalabs.sdk.models.box.Value
+import org.plasmalabs.sdk.models.{AssetMergingStatement, Datum, Event}
+import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule}
 import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps
 import org.plasmalabs.sdk.syntax.bigIntAsInt128
 import com.google.protobuf.struct.{Struct, Value => StructValue}
 import com.google.protobuf.struct.Value.Kind.StringValue
+import org.plasmalabs.quivr.models.SmallData
 
 class TransactionBuilderInterpreterAssetMergingSpec extends MergingSpecBase {
 
@@ -89,8 +91,17 @@ class TransactionBuilderInterpreterAssetMergingSpec extends MergingSpecBase {
       .run
     val merkleRoot = MergingOps.getAlloy(groupValues.map(_.getAsset))
     val expectedTx: IoTransaction = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 0)))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 0)))
+            )
+        )
+      )
       .withInputs(buildStxos(valuesToTxos(groupValues ++ Seq(lvlValue, lvlValue, lvlValue))))
       .withOutputs(
         buildRecipientUtxos(
@@ -124,8 +135,17 @@ class TransactionBuilderInterpreterAssetMergingSpec extends MergingSpecBase {
       .run
     val merkleRoot = MergingOps.getAlloy(assetValues.map(_.getAsset))
     val expectedTx: IoTransaction = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 1)))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 1)))
+            )
+        )
+      )
       .withInputs(buildStxos(valuesToTxos(assetValues ++ Seq(lvlValue, lvlValue, lvlValue))))
       .withOutputs(
         buildChangeUtxos(List(lvlValue.withLvl(lvlValue.getLvl.withQuantity(BigInt(2)))))

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
@@ -96,10 +96,9 @@ class TransactionBuilderInterpreterAssetMergingSpec extends MergingSpecBase {
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 0)))
+              SmallData.defaultInstance
             )
+            .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 0)))
         )
       )
       .withInputs(buildStxos(valuesToTxos(groupValues ++ Seq(lvlValue, lvlValue, lvlValue))))
@@ -140,10 +139,9 @@ class TransactionBuilderInterpreterAssetMergingSpec extends MergingSpecBase {
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 1)))
+              SmallData.defaultInstance
             )
+            .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 1)))
         )
       )
       .withInputs(buildStxos(valuesToTxos(assetValues ++ Seq(lvlValue, lvlValue, lvlValue))))

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
@@ -1,17 +1,16 @@
 package org.plasmalabs.sdk.builders
 
-import cats.implicits.catsSyntaxOptionId
+import cats.implicits.{catsSyntaxOptionId, showInterpolator}
 import org.plasmalabs.sdk.common.ContainsEvidence.Ops
 import org.plasmalabs.sdk.common.ContainsImmutable.instances.lockImmutable
-import org.plasmalabs.sdk.models.LockAddress
-import org.plasmalabs.sdk.models.LockId
+import org.plasmalabs.sdk.models.{AssetMergingStatement, Datum, Event, LockAddress, LockId}
 import org.plasmalabs.sdk.models.box.FungibilityType.GROUP
 import org.plasmalabs.sdk.models.box.FungibilityType.SERIES
 import org.plasmalabs.sdk.models.box.QuantityDescriptorType.ACCUMULATOR
 import org.plasmalabs.sdk.models.box.QuantityDescriptorType.FRACTIONABLE
 import org.plasmalabs.sdk.models.box.QuantityDescriptorType.IMMUTABLE
 import org.plasmalabs.sdk.models.box.Value
-import org.plasmalabs.sdk.models.transaction.IoTransaction
+import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule}
 import org.plasmalabs.sdk.syntax.LvlType
 import org.plasmalabs.sdk.syntax.assetAsBoxVal
 import org.plasmalabs.sdk.syntax.bigIntAsInt128
@@ -22,7 +21,7 @@ import org.plasmalabs.sdk.syntax.ioTransactionAsTransactionSyntaxOps
 import org.plasmalabs.sdk.syntax.seriesAsBoxVal
 import org.plasmalabs.sdk.syntax.seriesPolicyAsSeriesPolicySyntaxOps
 import org.plasmalabs.sdk.syntax.valueToTypeIdentifierSyntaxOps
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.{Int128, SmallData}
 
 class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderInterpreterSpecBase {
 
@@ -227,8 +226,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       newSeries :+ newGroup :+ newLvl
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -250,8 +258,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(groupValue, txAddr = mockGroupPolicyAlt.registrationUtxo) :+
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo)
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -286,8 +303,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -329,8 +355,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -371,8 +406,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -407,8 +451,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -437,8 +490,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -469,8 +531,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       groupTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -499,8 +570,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -532,8 +612,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output
@@ -565,8 +654,17 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
       valToTxo(seriesValue, txAddr = mockSeriesPolicyAlt.registrationUtxo) :+
       seriesTxo
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(mockAssetMintingStatement))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withMintingStatements(Seq(mockAssetMintingStatement))
+            )
+        )
+      )
       .withInputs(buildStxos(allTxos))
       .withOutputs(
         // minted output

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
@@ -231,10 +231,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -263,10 +262,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -308,10 +306,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -360,10 +357,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -411,10 +407,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -456,10 +451,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -495,10 +489,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -536,10 +529,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -575,10 +567,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -617,10 +608,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))
@@ -659,10 +649,9 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withMintingStatements(Seq(mockAssetMintingStatement))
+              SmallData.defaultInstance
             )
+            .withMintingStatements(Seq(mockAssetMintingStatement))
         )
       )
       .withInputs(buildStxos(allTxos))

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
@@ -1,7 +1,8 @@
 package org.plasmalabs.sdk.builders
 
-import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.models.Datum
+import org.plasmalabs.quivr.models.SmallData
+import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule}
+import org.plasmalabs.sdk.models.{Datum, Event}
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.syntax.{ioTransactionAsTransactionSyntaxOps, valueToTypeIdentifierSyntaxOps, LvlType}
 
@@ -10,8 +11,17 @@ class TransactionBuilderInterpreterGroupMintingSpec extends TransactionBuilderIn
   test("Success") {
     val txRes = buildMintGroupTransaction.run
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withGroupPolicies(Seq(Datum.GroupPolicy(mockGroupPolicyAlt)))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withGroupPolicies(Seq(mockGroupPolicyAlt))
+            )
+        )
+      )
       .withInputs(buildStxos(mockTxos :+ valToTxo(lvlValue, txAddr = mockGroupPolicyAlt.registrationUtxo)))
       .withOutputs(
         // minted output

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
@@ -16,10 +16,9 @@ class TransactionBuilderInterpreterGroupMintingSpec extends TransactionBuilderIn
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withGroupPolicies(Seq(mockGroupPolicyAlt))
+              SmallData.defaultInstance
             )
+            .withGroupPolicies(Seq(mockGroupPolicyAlt))
         )
       )
       .withInputs(buildStxos(mockTxos :+ valToTxo(lvlValue, txAddr = mockGroupPolicyAlt.registrationUtxo)))

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
@@ -1,7 +1,8 @@
 package org.plasmalabs.sdk.builders
 
-import org.plasmalabs.sdk.models.transaction.IoTransaction
-import org.plasmalabs.sdk.models.Datum
+import org.plasmalabs.quivr.models.SmallData
+import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule}
+import org.plasmalabs.sdk.models.{Datum, Event}
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.syntax.{ioTransactionAsTransactionSyntaxOps, valueToTypeIdentifierSyntaxOps, LvlType}
 
@@ -10,8 +11,17 @@ class TransactionBuilderInterpreterSeriesMintingSpec extends TransactionBuilderI
   test("Success") {
     val txRes = buildMintSeriesTransaction.run
     val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withSeriesPolicies(Seq(Datum.SeriesPolicy(mockSeriesPolicyAlt)))
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData.defaultInstance,
+              Event.IoTransaction.Policies.defaultInstance
+                .withSeriesPolicies(Seq(mockSeriesPolicyAlt))
+            )
+        )
+      )
       .withInputs(buildStxos(mockTxos :+ valToTxo(lvlValue, txAddr = mockSeriesPolicyAlt.registrationUtxo)))
       .withOutputs(
         // minted output

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
@@ -16,10 +16,9 @@ class TransactionBuilderInterpreterSeriesMintingSpec extends TransactionBuilderI
           Event
             .IoTransaction(
               Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData.defaultInstance,
-              Event.IoTransaction.Policies.defaultInstance
-                .withSeriesPolicies(Seq(mockSeriesPolicyAlt))
+              SmallData.defaultInstance
             )
+            .withSeriesPolicies(Seq(mockSeriesPolicyAlt))
         )
       )
       .withInputs(buildStxos(mockTxos :+ valToTxo(lvlValue, txAddr = mockSeriesPolicyAlt.registrationUtxo)))

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterSpecBase.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/TransactionBuilderInterpreterSpecBase.scala
@@ -12,8 +12,8 @@ import org.plasmalabs.sdk.builders.TransactionBuilderInterpreterSpecBase.{
 }
 import org.plasmalabs.sdk.common.ContainsImmutable.ContainsImmutableTOps
 import org.plasmalabs.sdk.common.ContainsImmutable.instances.{spentOutputImmutable, unspentOutputImmutable}
-import org.plasmalabs.sdk.models.Event.{GroupPolicy, SeriesPolicy}
-import org.plasmalabs.sdk.models.box.{AssetMintingStatement, Lock, Value}
+import org.plasmalabs.sdk.models.{AssetMintingStatement, GroupPolicy, SeriesPolicy}
+import org.plasmalabs.sdk.models.box.{Lock, Value}
 import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import org.plasmalabs.sdk.models.{LockAddress, TransactionOutputAddress}
 import org.plasmalabs.sdk.syntax.{

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/locks/LockTemplateSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/locks/LockTemplateSpec.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.sdk.builders.locks
 
 import cats.Id
-import quivr.models.Proposition.Value._
+import org.plasmalabs.quivr.models.Proposition.Value._
 import org.plasmalabs.sdk.MockHelpers
 import org.plasmalabs.sdk.builders.locks.PropositionTemplate.UnableToBuildPropositionTemplate
 import org.plasmalabs.sdk.models.box.Lock.Value.Predicate

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/locks/PropositionTemplateSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/builders/locks/PropositionTemplateSpec.scala
@@ -4,8 +4,8 @@ import cats.Id
 import org.plasmalabs.sdk.MockHelpers
 import org.plasmalabs.sdk.builders.locks.PropositionTemplate.UnableToBuildPropositionTemplate
 import com.google.protobuf.ByteString
-import quivr.models.Data
-import quivr.models.Proposition.Value._
+import org.plasmalabs.quivr.models.Data
+import org.plasmalabs.quivr.models.Proposition.Value._
 
 class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/codecs/PropositionTemplateCodecsSpecBase.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/codecs/PropositionTemplateCodecsSpecBase.scala
@@ -18,7 +18,7 @@ import org.plasmalabs.sdk.builders.locks.PropositionTemplate.{
 import org.plasmalabs.sdk.utils.Encoding.encodeToBase58
 import com.google.protobuf.ByteString
 import io.circe.Json
-import quivr.models.Data
+import org.plasmalabs.quivr.models.Data
 
 trait PropositionTemplateCodecsSpecBase extends MockHelpers {
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/display/DisplaySpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/display/DisplaySpec.scala
@@ -6,59 +6,58 @@ import org.plasmalabs.sdk.MockHelpers
 import org.plasmalabs.sdk.MockWalletKeyApi
 import org.plasmalabs.sdk.MockWalletStateApi
 import org.plasmalabs.sdk.display.DisplayOps.DisplayTOps
-import org.plasmalabs.sdk.models.Datum
-import org.plasmalabs.sdk.models.Event
+import org.plasmalabs.sdk.models.{AssetMintingStatement, Datum, Event}
 import org.plasmalabs.sdk.models.box._
-import org.plasmalabs.sdk.models.transaction.Schedule
+import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule}
 import org.plasmalabs.sdk.syntax.bigIntAsInt128
 import org.plasmalabs.sdk.syntax.longAsInt128
 import org.plasmalabs.sdk.wallet.CredentiallerInterpreter
 import org.plasmalabs.sdk.wallet.WalletApi
 import com.google.protobuf.ByteString
-import quivr.models.Proof
-import quivr.models.SmallData
+import org.plasmalabs.quivr.models.Proof
+import org.plasmalabs.quivr.models.SmallData
 import org.plasmalabs.quivr.api.Proposer
 
 class DisplaySpec extends munit.FunSuite with MockHelpers {
 
   test("Display Complex Transaction") {
-    val testTx = txFull
-      .withDatum(
-        Datum.IoTransaction(
-          Event
-            .IoTransaction(
-              Schedule(0, Long.MaxValue, System.currentTimeMillis),
-              SmallData(ByteString.copyFrom("metadata".getBytes))
-            )
+    val testTx =
+      IoTransaction.defaultInstance
+        .withDatum(
+          Datum.IoTransaction(
+            Event
+              .IoTransaction(
+                Schedule(0, Long.MaxValue, System.currentTimeMillis),
+                SmallData(ByteString.copyFrom("metadata".getBytes)),
+                policies = Event.IoTransaction.Policies.defaultInstance
+                  .withGroupPolicies(Seq(mockGroupPolicy))
+                  .withSeriesPolicies(Seq(mockSeriesPolicy))
+                  .withMintingStatements(
+                    Seq(AssetMintingStatement(mockGroupPolicy.registrationUtxo, mockSeriesPolicy.registrationUtxo, 1))
+                  )
+              )
+          )
         )
-      )
-      .withGroupPolicies(Seq(Datum.GroupPolicy(mockGroupPolicy)))
-      .withSeriesPolicies(Seq(Datum.SeriesPolicy(mockSeriesPolicy)))
-      .withMintingStatements(
-        Seq(
-          AssetMintingStatement(mockGroupPolicy.registrationUtxo, mockSeriesPolicy.registrationUtxo, 1)
+        .withInputs(
+          Seq(
+            lvlValue,
+            groupValue,
+            seriesValue,
+            assetGroupSeries
+          ).map(value => inputFull.withValue(value))
         )
-      )
-      .withInputs(
-        Seq(
-          lvlValue,
-          groupValue,
-          seriesValue,
-          assetGroupSeries
-        ).map(value => inputFull.withValue(value))
-      )
-      .withOutputs(
-        Seq(
-          lvlValue,
-          groupValue,
-          seriesValue,
-          assetGroupSeries
-        ).map(value => output.withValue(value))
-      )
+        .withOutputs(
+          Seq(
+            lvlValue,
+            groupValue,
+            seriesValue,
+            assetGroupSeries
+          ).map(value => output.withValue(value))
+        )
     assertNoDiff(
       testTx.display.trim(),
       s"""
-TransactionId              : 3G1TsJUpmurYxMnzQ8NaBrnK3DymVGzRKLUwLysinjb6
+TransactionId              : AQQiYaYH5FGspd5R4sCkKDdQszHWdTTYPThL12PJ3od2
 
 Group Policies
 ==============

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/display/DisplaySpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/display/DisplaySpec.scala
@@ -28,13 +28,12 @@ class DisplaySpec extends munit.FunSuite with MockHelpers {
             Event
               .IoTransaction(
                 Schedule(0, Long.MaxValue, System.currentTimeMillis),
-                SmallData(ByteString.copyFrom("metadata".getBytes)),
-                policies = Event.IoTransaction.Policies.defaultInstance
-                  .withGroupPolicies(Seq(mockGroupPolicy))
-                  .withSeriesPolicies(Seq(mockSeriesPolicy))
-                  .withMintingStatements(
-                    Seq(AssetMintingStatement(mockGroupPolicy.registrationUtxo, mockSeriesPolicy.registrationUtxo, 1))
-                  )
+                SmallData(ByteString.copyFrom("metadata".getBytes))
+              )
+              .withGroupPolicies(Seq(mockGroupPolicy))
+              .withSeriesPolicies(Seq(mockSeriesPolicy))
+              .withMintingStatements(
+                Seq(AssetMintingStatement(mockGroupPolicy.registrationUtxo, mockSeriesPolicy.registrationUtxo, 1))
               )
           )
         )

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/generators/ModelGenerators.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/generators/ModelGenerators.scala
@@ -7,8 +7,8 @@ import org.plasmalabs.quivr.generators.ModelGenerators.arbitraryDigest
 import com.google.protobuf.ByteString
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import quivr.models.Int128
-import quivr.models.Proof
+import org.plasmalabs.quivr.models.Int128
+import org.plasmalabs.quivr.models.Proof
 
 import java.util.Random
 
@@ -164,9 +164,9 @@ trait EventGenerator {
       for {
         schedule <- arbitrarySchedule.arbitrary
         metadata <- Gen.const(
-          quivr.models.SmallData.of(ByteString.EMPTY)
-        ) // TODO create Small Data generator: QuivrRepo
-      } yield Event.IoTransaction.of(schedule, metadata)
+          org.plasmalabs.quivr.models.SmallData.of(ByteString.EMPTY)
+        ) // TODO create Small Data generator: QuivrRepo, and Data Generator Policies
+      } yield Event.IoTransaction.of(schedule, metadata, Event.IoTransaction.Policies())
     )
 
 }

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/generators/ModelGenerators.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/generators/ModelGenerators.scala
@@ -166,7 +166,7 @@ trait EventGenerator {
         metadata <- Gen.const(
           org.plasmalabs.quivr.models.SmallData.of(ByteString.EMPTY)
         ) // TODO create Small Data generator: QuivrRepo, and Data Generator Policies
-      } yield Event.IoTransaction.of(schedule, metadata, Event.IoTransaction.Policies())
+      } yield Event.IoTransaction.of(schedule, metadata, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty)
     )
 
 }

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/syntax/BoxValueSyntaxSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/syntax/BoxValueSyntaxSpec.scala
@@ -3,7 +3,7 @@ package org.plasmalabs.sdk.syntax
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.box.Value.{Value => BoxValue}
 import com.google.protobuf.ByteString
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.Int128
 import org.plasmalabs.sdk.MockHelpers
 
 class BoxValueSyntaxSpec extends munit.FunSuite with MockHelpers {

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/syntax/Int128SyntaxSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/syntax/Int128SyntaxSpec.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.sdk.syntax
 
 import org.plasmalabs.sdk.MockHelpers
 import com.google.protobuf.ByteString
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.Int128
 
 class Int128SyntaxSpec extends munit.FunSuite with MockHelpers {
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
@@ -7,11 +7,11 @@ import org.plasmalabs.sdk.builders.MergingOps
 import org.plasmalabs.sdk.common.ContainsEvidence.Ops
 import org.plasmalabs.sdk.common.ContainsImmutable.instances.lockImmutable
 import org.plasmalabs.sdk.models.box._
-import org.plasmalabs.sdk.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
-import org.plasmalabs.sdk.models.{GroupId, LockAddress, LockId, SeriesId}
+import org.plasmalabs.sdk.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
+import org.plasmalabs.sdk.models.{AssetMergingStatement, Datum, Event, GroupId, LockAddress, LockId, SeriesId}
 import org.plasmalabs.indexer.services.Txo
 import com.google.protobuf.ByteString
-import quivr.models.Int128
+import org.plasmalabs.quivr.models.{Int128, SmallData}
 
 /**
  * Test to coverage Asset Merging:
@@ -89,7 +89,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         txo.transactionOutput.value
       )) :+ SpentTransactionOutput(dummyTxoAddress, mockAttestation, lvlValue)
     val outputs = Seq(UnspentTransactionOutput(mockLockAddress, lvlValue), mergedGroup, mergedSeries)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmSeries))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup, asmSeries))
+                )
+            )
+        )
 
     val result = validator.validate(testTx)
 
@@ -106,8 +121,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- groupTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mergedGroup, mergedGroup)
+
     val testTx =
-      mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup, asmGroupDup))
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup, asmGroupDup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -126,7 +155,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- groupTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(MergingOps.merge(groupTxos :+ groupTxos.head, mockLockAddress, None, None))
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -143,7 +187,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val inputs =
       Seq(SpentTransactionOutput(groupTxos.head.outputAddress, mockAttestation, groupTxos.head.transactionOutput.value))
     val outputs = Seq(MergingOps.merge(Seq(groupTxos.head), mockLockAddress, None, None))
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -161,7 +220,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- groupTxos.tail)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(MergingOps.merge(groupTxos.tail, mockLockAddress, None, None))
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -179,7 +253,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- groupTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq()
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -197,7 +286,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- groupTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mergedGroup, UnspentTransactionOutput(mockLockAddress, groupTxos.head.transactionOutput.value))
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -220,7 +324,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
     val asmGroup = AssetMergingStatement(groupTxos.map(_.outputAddress), 0)
     val inputs = for (txo <- groupTxos) yield SpentTransactionOutput(txo.outputAddress, mockAttestation, lvlValue)
     val outputs = for (_ <- groupTxos.indices) yield UnspentTransactionOutput(mockLockAddress, lvlValue)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -240,7 +359,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- groupTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(UnspentTransactionOutput(mockLockAddress, lvlValue))
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -278,7 +412,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- groupSeriesTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mergedGroupSeries)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroupSeries))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroupSeries))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -302,7 +451,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- mockTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -328,7 +492,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         mergedGroup.value.withAsset(mergedGroup.value.getAsset.withFungibility(FungibilityType.SERIES))
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -358,7 +537,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- mockTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -386,7 +580,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -417,7 +626,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- mockTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -445,7 +669,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -468,7 +707,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs =
       Seq(mergedGroup.copy(value = mergedGroup.value.withAsset(mergedGroup.value.getAsset.clearSeriesAlloy)))
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -496,8 +750,21 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
-
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
     val result = validator.validate(testTx).swap
 
     val assertError = result.exists(
@@ -524,8 +791,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
 
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
     val result = validator.validate(testTx).swap
 
     val assertError = result.exists(
@@ -555,7 +836,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
       for (txo <- mockTxos)
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs = Seq(mockOutput)
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asm))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -583,7 +879,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -606,7 +917,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         yield SpentTransactionOutput(txo.outputAddress, mockAttestation, txo.transactionOutput.value)
     val outputs =
       Seq(mergedSeries.copy(value = mergedSeries.value.withAsset(mergedSeries.value.getAsset.clearGroupAlloy)))
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -634,7 +960,22 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -662,7 +1003,21 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 
@@ -690,7 +1045,21 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
         )
       )
     )
-    val testTx = mockTransaction.withInputs(inputs).withOutputs(outputs).withMergingStatements(Seq(asmGroup))
+    val testTx =
+      IoTransaction.defaultInstance
+        .withInputs(inputs)
+        .withOutputs(outputs)
+        .withDatum(
+          Datum.IoTransaction.defaultInstance
+            .withEvent(
+              Event.IoTransaction.defaultInstance
+                .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
+                .withMetadata(SmallData.defaultInstance)
+                .withPolicies(
+                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
+                )
+            )
+        )
 
     val result = validator.validate(testTx).swap
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetMergingSpec.scala
@@ -100,9 +100,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup, asmSeries))
-                )
+                .withMergingStatements(Seq(asmGroup, asmSeries))
             )
         )
 
@@ -132,9 +130,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup, asmGroupDup))
-                )
+                .withMergingStatements(Seq(asmGroup, asmGroupDup))
             )
         )
 
@@ -166,9 +162,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -198,9 +192,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -231,9 +223,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -264,9 +254,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -297,9 +285,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -335,9 +321,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -370,9 +354,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -423,9 +405,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroupSeries))
-                )
+                .withMergingStatements(Seq(asmGroupSeries))
             )
         )
 
@@ -462,9 +442,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
-                )
+                .withMergingStatements(Seq(asm))
             )
         )
 
@@ -503,9 +481,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -548,9 +524,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
-                )
+                .withMergingStatements(Seq(asm))
             )
         )
 
@@ -591,9 +565,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -637,9 +609,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
-                )
+                .withMergingStatements(Seq(asm))
             )
         )
 
@@ -680,9 +650,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -718,9 +686,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -760,9 +726,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
     val result = validator.validate(testTx).swap
@@ -802,9 +766,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
     val result = validator.validate(testTx).swap
@@ -847,9 +809,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asm))
-                )
+                .withMergingStatements(Seq(asm))
             )
         )
 
@@ -890,9 +850,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -928,9 +886,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -971,9 +927,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -1013,9 +967,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 
@@ -1055,9 +1007,7 @@ class TransactionSyntaxInterpreterAssetMergingSpec extends munit.FunSuite with M
               Event.IoTransaction.defaultInstance
                 .withSchedule(Schedule(0, Long.MaxValue, System.currentTimeMillis))
                 .withMetadata(SmallData.defaultInstance)
-                .withPolicies(
-                  Event.IoTransaction.Policies.defaultInstance.withMergingStatements(Seq(asmGroup))
-                )
+                .withMergingStatements(Seq(asmGroup))
             )
         )
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -3,9 +3,7 @@ package org.plasmalabs.sdk.validation
 import cats.Id
 import cats.implicits._
 import org.plasmalabs.sdk.MockHelpers
-import org.plasmalabs.sdk.models.Event
-import org.plasmalabs.sdk.models.TransactionOutputAddress
-import org.plasmalabs.sdk.models.box.AssetMintingStatement
+import org.plasmalabs.sdk.models.{AssetMintingStatement, Event, GroupPolicy, SeriesPolicy, TransactionOutputAddress}
 import org.plasmalabs.sdk.models.box.FungibilityType
 import org.plasmalabs.sdk.models.box.QuantityDescriptorType.IMMUTABLE
 import org.plasmalabs.sdk.models.box.QuantityDescriptorType.LIQUID
@@ -30,7 +28,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 1
    */
   test("Invalid data-input case 0+0 != 1") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val value_1: Value =
       Value.defaultInstance.withAsset(
         Value.Asset(
@@ -40,7 +38,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1)
-    val testTx = txFull.copy(outputs = List(output_1), mintingStatements = Seq.empty)
+    val testTx = txFull.copy(outputs = List(output_1))
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -64,7 +62,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 1
    */
   test("Valid data-input case") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
       Value.defaultInstance.withAsset(
         Value.Asset(
@@ -90,8 +88,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
 
     val testTx = txFull.copy(
       inputs = List(input_1),
-      outputs = List(output_1),
-      mintingStatements = Seq.empty
+      outputs = List(output_1)
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -117,8 +114,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - The asset is not the same, first contains a groupId
    */
   test("Invalid data-input case not equals assets") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withAsset(
         Value.Asset(
@@ -142,8 +139,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
 
     val testTx = txFull.copy(
       inputs = List(input_1),
-      outputs = List(output_1),
-      mintingStatements = Seq.empty
+      outputs = List(output_1)
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -170,7 +166,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    */
   test("Invalid data-input case: not equals quantity") {
 
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
 
     val value_1_in: Value =
       Value.defaultInstance.withAsset(
@@ -193,7 +189,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), mintingStatements = Seq.empty)
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1))
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -218,7 +214,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 1
    */
   test("Invalid data-input case, equals assets,  2 + 0 != 1") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
       Value.defaultInstance.withAsset(
         Value.Asset(
@@ -242,7 +238,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1), mintingStatements = Seq.empty)
+    val testTx = txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1))
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -268,7 +264,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 1
    */
   test("Valid data-input case, input(1) + minted(0) == output(1)") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
       Value.defaultInstance.withAsset(
         Value.Asset(
@@ -292,7 +288,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), mintingStatements = List.empty)
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1))
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -315,8 +311,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 1
    */
   test("Valid data-input case, input(0) + minted(1) == output(1)") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
@@ -351,7 +347,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val mintingStatements =
       List(AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_2, quantity = BigInt(1)))
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -376,8 +375,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 1
    */
   test("Invalid data-input case, input + minted == output") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
@@ -410,7 +409,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List.empty)
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -436,8 +435,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 2
    */
   test("Invalid data-input case, input + minted == output") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
@@ -478,7 +477,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -504,8 +506,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 1
    */
   test("Invalid data-input case, input + minted == output") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
@@ -545,7 +547,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -571,8 +576,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - asset output = 2
    */
   test("Valid data-input case, input + minted == output") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withGroup(
         Value.Group(
@@ -640,8 +645,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_3_out),
       UnspentTransactionOutput(trivialLockAddress, value_4_out)
     )
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -668,8 +675,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * - Fungibility Type is not the same
    */
   test("Invalid data-input case, input + minted == output") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withGroup(
         Value.Group(
@@ -732,7 +739,9 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_4_out)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -763,8 +772,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * We still expected failure because the second output's (groupId, seriesId) is not from minting or inputs.
    */
   test("Invalid data-input case, unexpected asset output") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val group_in: Value =
       Value.defaultInstance.withGroup(
         Value.Group(
@@ -825,7 +834,9 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, invalid_out)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List(mintingStatement))
+    val policies = txFull.datum.event.policies.copy(mintingStatements = Seq(mintingStatement))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -853,8 +864,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * Both output's (groupId, seriesId) match the AMS, but both have invalid fields.
    */
   test("Invalid data-input case, invalid fields in minted asset") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val group_in: Value =
       Value.defaultInstance.withGroup(
         Value.Group(
@@ -898,10 +909,12 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val series_out: Value =
       Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
-    val mintingStatement = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(1)
+    val mintingStatements = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(1)
+      )
     )
 
     val inputs = List(
@@ -915,7 +928,9 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, minted_out_invalidQuantity)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List(mintingStatement))
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -943,8 +958,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * Both output's (groupId, seriesId) match the AMS, but only the first has valid fields.
    */
   test("Invalid data-input case, invalid fields in one minted asset") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val group_in: Value =
       Value.defaultInstance.withGroup(
         Value.Group(
@@ -988,10 +1003,12 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val series_out: Value =
       Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
-    val mintingStatement = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(1)
+    val mintingStatements = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(1)
+      )
     )
 
     val inputs = List(
@@ -1005,7 +1022,9 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, minted_out_invalid)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List(mintingStatement))
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -1033,8 +1052,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
    * Asset outputs has invalid fields (compared to its input).
    */
   test("Invalid data-input case, invalid fields in transferred assets") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
 
     val asset_in: Value =
       Value.defaultInstance.withAsset(
@@ -1075,7 +1094,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, asset_out_invalidQuantityDescriptor)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = Seq.empty)
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -347,8 +347,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val mintingStatements =
       List(AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_2, quantity = BigInt(1)))
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
@@ -477,8 +476,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
@@ -547,8 +545,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
@@ -645,8 +642,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_3_out),
       UnspentTransactionOutput(trivialLockAddress, value_4_out)
     )
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
@@ -739,8 +736,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_4_out)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -834,8 +830,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, invalid_out)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = Seq(mintingStatement))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = Seq(mintingStatement)))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -928,8 +923,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, minted_out_invalidQuantity)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -1022,8 +1016,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, minted_out_invalid)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
@@ -3,9 +3,7 @@ package org.plasmalabs.sdk.validation
 import cats.Id
 import cats.implicits._
 import org.plasmalabs.sdk.MockHelpers
-import org.plasmalabs.sdk.models.Datum
-import org.plasmalabs.sdk.models.Event
-import org.plasmalabs.sdk.models.TransactionOutputAddress
+import org.plasmalabs.sdk.models.{Datum, Event, GroupPolicy, TransactionOutputAddress}
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.SpentTransactionOutput
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
@@ -25,7 +23,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
   private val txoAddress_2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
   test("Valid data-input case 1, minting a Group constructor Token") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
         Value.LVL(
@@ -44,11 +42,10 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      groupPolicies = List(Datum.GroupPolicy(groupPolicy))
-    )
+    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -68,7 +65,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
    * reference in policy contains LVLs (> 0)
    */
   test("Invalid data-input case 2, minting a Group constructor Token") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
         Value.LVL(
@@ -87,11 +84,9 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      groupPolicies = List(Datum.GroupPolicy(groupPolicy))
-    )
+    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -114,7 +109,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
    * reference in policy contains LVLs (> 0), registrationUtxo on policy is different that input_1
    */
   test("Invalid data-input case 3, minting a Group constructor Token") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
         Value.LVL(
@@ -133,11 +128,9 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      groupPolicies = List(Datum.GroupPolicy(groupPolicy))
-    )
+    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -161,7 +154,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
    * there is no constraint about the amount of constructor token quantity == 10000000 and LVL quantity
    */
   test("Valid data-input case 4, minting a Group constructor Token") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
 
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
@@ -181,11 +174,9 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      groupPolicies = List(Datum.GroupPolicy(groupPolicy))
-    )
+    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
@@ -42,8 +42,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(groupPolicies = Seq(groupPolicy)))
 
     val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
@@ -84,8 +83,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(groupPolicies = Seq(groupPolicy)))
     val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -128,8 +126,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(groupPolicies = Seq(groupPolicy)))
     val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -174,8 +171,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val policies = txFull.datum.event.policies.copy(groupPolicies = Seq(groupPolicy))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(groupPolicies = Seq(groupPolicy)))
     val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
@@ -3,9 +3,7 @@ package org.plasmalabs.sdk.validation
 import cats.Id
 import cats.implicits._
 import org.plasmalabs.sdk.MockHelpers
-import org.plasmalabs.sdk.models.Datum
-import org.plasmalabs.sdk.models.Event
-import org.plasmalabs.sdk.models.TransactionOutputAddress
+import org.plasmalabs.sdk.models.{Datum, Event, SeriesPolicy, TransactionOutputAddress}
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.SpentTransactionOutput
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
@@ -25,7 +23,7 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
   private val txoAddress_2 = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
   test("Valid data-input case 1, minting a Series constructor Token") {
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
         Value.LVL(
@@ -44,11 +42,9 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      seriesPolicies = List(Datum.SeriesPolicy(seriesPolicy))
-    )
+    val policies = txFull.datum.event.policies.copy(seriesPolicies = Seq(seriesPolicy))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -68,7 +64,7 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
    * reference in policy contains LVLs (> 0)
    */
   test("Invalid data-input case 2, minting a Series constructor Token") {
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
         Value.LVL(
@@ -87,11 +83,9 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      seriesPolicies = List(Datum.SeriesPolicy(seriesPolicy))
-    )
+    val policies = txFull.datum.event.policies.copy(seriesPolicies = Seq(seriesPolicy))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -114,7 +108,7 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
    * reference in policy contains LVLs (> 0), registrationUtxo on policy is different that input_1
    */
   test("Invalid data-input case 3, minting a Series constructor Token") {
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
         Value.LVL(
@@ -133,11 +127,9 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      seriesPolicies = List(Datum.SeriesPolicy(seriesPolicy))
-    )
+    val policies = txFull.datum.event.policies.copy(seriesPolicies = Seq(seriesPolicy))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
@@ -42,8 +42,7 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val policies = txFull.datum.event.policies.copy(seriesPolicies = Seq(seriesPolicy))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(seriesPolicies = Seq(seriesPolicy)))
     val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -83,8 +82,7 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val policies = txFull.datum.event.policies.copy(seriesPolicies = Seq(seriesPolicy))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(seriesPolicies = Seq(seriesPolicy)))
     val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -127,8 +125,7 @@ class TransactionSyntaxInterpreterMintingCaseBSpec extends munit.FunSuite with M
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val policies = txFull.datum.event.policies.copy(seriesPolicies = Seq(seriesPolicy))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(seriesPolicies = Seq(seriesPolicy)))
     val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -3,9 +3,8 @@ package org.plasmalabs.sdk.validation
 import cats.Id
 import cats.implicits._
 import org.plasmalabs.sdk.MockHelpers
-import org.plasmalabs.sdk.models.Event
-import org.plasmalabs.sdk.models.TransactionOutputAddress
-import org.plasmalabs.sdk.models.box.AssetMintingStatement
+import org.plasmalabs.sdk.models.{Event, GroupPolicy, SeriesPolicy, TransactionOutputAddress}
+import org.plasmalabs.sdk.models.AssetMintingStatement
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.SpentTransactionOutput
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
@@ -25,8 +24,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   private val txoAddress_4 = TransactionOutputAddress(0, 0, 4, dummyTxIdentifier)
 
   test("Valid data-input case 1, minting a Asset Token Unlimited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = None)
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = None)
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -60,17 +59,18 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
     val output_3 = UnspentTransactionOutput(trivialLockAddress, value_3_out)
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(1)
+    val mintingStatement_1 = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(1)
+      )
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2, output_3),
-      mintingStatements = List(mintingStatement_1)
-    )
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx =
+      txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1, output_2, output_3), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -80,9 +80,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Valid data-input case 1, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = 1))
@@ -119,12 +118,14 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
 
     val mintingStatement_1 =
-      AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_2, quantity = 10)
+      Seq(AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_2, quantity = 10))
 
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
+      datum = datum
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -135,9 +136,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Valid data-input case 2, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -194,7 +194,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -204,9 +206,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Valid data-input case 3, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -252,16 +253,20 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
     val output_3 = UnspentTransactionOutput(trivialLockAddress, value_3_out)
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(10)
+    val mintingStatement_1 = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(10)
+      )
     )
 
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2, output_3),
-      mintingStatements = List(mintingStatement_1)
+      datum = datum
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -272,9 +277,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Valid data-input case 4, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -319,16 +323,20 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
     val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(20)
+    val mintingStatement_1 = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(20)
+      )
     )
 
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
+      datum = datum
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -339,9 +347,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Valid data-input case 5, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -389,7 +396,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -400,16 +409,16 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   test("Valid data-input case 6, minting a Asset Token Limited and transfer Other Asset") {
     val groupPolicy =
-      Event.GroupPolicy(label = "policy", registrationUtxo = txoAddress_1)
+      GroupPolicy(label = "policy", registrationUtxo = txoAddress_1)
 
     val groupPolicy_A =
-      Event.GroupPolicy(label = "policy_A", registrationUtxo = txoAddress_3)
+      GroupPolicy(label = "policy_A", registrationUtxo = txoAddress_3)
 
     val seriesPolicy =
-      Event.SeriesPolicy(label = "series", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+      SeriesPolicy(label = "series", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val seriesPolicy_A =
-      Event.SeriesPolicy(label = "series_A", registrationUtxo = txoAddress_4, tokenSupply = Some(10))
+      SeriesPolicy(label = "series_A", registrationUtxo = txoAddress_4, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -490,7 +499,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -500,9 +511,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Invalid data-input case 1, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -536,17 +546,17 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
     val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(11) // Invalid data
+    val mintingStatements = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(11) // Invalid data
+      )
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
-    )
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1, output_2), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -566,9 +576,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Invalid data-input case 2, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -602,17 +611,17 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
     val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(10)
+    val mintingStatements = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(10)
+      )
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
-    )
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1, output_2), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -632,9 +641,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
   }
 
   test("Invalid data-input case 3, minting a Asset Token Limited") {
-    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
-    val seriesPolicy =
-      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(3))
+    val groupPolicy = GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(3))
 
     val value_1_in: Value =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
@@ -668,16 +676,20 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
     val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2)
+    val mintingStatements = Seq(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(2)
+      )
     )
 
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
+      datum = datum
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -709,10 +721,10 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
     val dummyTxoAddress = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
 
-    val g1 = Event.GroupPolicy(label = "policyG1", registrationUtxo = utxo_xyz)
-    val g2 = Event.GroupPolicy(label = "policyG2", registrationUtxo = utxo_uvw)
+    val g1 = GroupPolicy(label = "policyG1", registrationUtxo = utxo_xyz)
+    val g2 = GroupPolicy(label = "policyG2", registrationUtxo = utxo_uvw)
 
-    val s1 = Event.SeriesPolicy(label = "policyS1", registrationUtxo = dummyTxoAddress, tokenSupply = Some(1))
+    val s1 = SeriesPolicy(label = "policyS1", registrationUtxo = dummyTxoAddress, tokenSupply = Some(1))
 
     val value_abc_in: Value =
       Value.defaultInstance.withSeries(
@@ -778,10 +790,12 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       quantity = BigInt(1)
     )
 
+    val policies = txFull.datum.event.policies.copy(mintingStatements = List(mintingStatement_1, mintingStatement_2))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
     val testTx = txFull.copy(
       inputs = List(input_abc, input_def, input_xyz, input_uvw),
       outputs = List(output_1, output_2, output_3, output_4, output_5),
-      mintingStatements = List(mintingStatement_1, mintingStatement_2)
+      datum = datum
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -812,10 +826,10 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
     val dummyTxoAddress = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
 
-    val g1 = Event.GroupPolicy(label = "policyG1", registrationUtxo = utxo_xyz)
-    val g2 = Event.GroupPolicy(label = "policyG2", registrationUtxo = utxo_uvw)
+    val g1 = GroupPolicy(label = "policyG1", registrationUtxo = utxo_xyz)
+    val g2 = GroupPolicy(label = "policyG2", registrationUtxo = utxo_uvw)
 
-    val s1 = Event.SeriesPolicy(label = "policyS1", registrationUtxo = dummyTxoAddress, tokenSupply = Some(1))
+    val s1 = SeriesPolicy(label = "policyS1", registrationUtxo = dummyTxoAddress, tokenSupply = Some(1))
 
     val value_abc_in: Value =
       Value.defaultInstance.withSeries(
@@ -881,10 +895,12 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       quantity = BigInt(1)
     )
 
+    val policies = txFull.datum.event.policies.copy(mintingStatements = List(mintingStatement_1, mintingStatement_2))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
     val testTx = txFull.copy(
       inputs = List(input_abc, input_def, input_xyz, input_uvw),
       outputs = List(output_1, output_2, output_3, output_4, output_5),
-      mintingStatements = List(mintingStatement_1, mintingStatement_2)
+      datum = datum
     )
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -914,10 +930,10 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val utxo3 = TransactionOutputAddress(0, 0, 3, dummyTxIdentifier)
     val utxo4 = TransactionOutputAddress(0, 0, 4, dummyTxIdentifier)
 
-    val gA = Event.GroupPolicy(label = "policyGA", registrationUtxo = utxo1)
-    val gB = Event.GroupPolicy(label = "policyGB", registrationUtxo = utxo2)
+    val gA = GroupPolicy(label = "policyGA", registrationUtxo = utxo1)
+    val gB = GroupPolicy(label = "policyGB", registrationUtxo = utxo2)
 
-    val sC = Event.SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
+    val sC = SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
 
     // inputs
     val inValue1_GA: Value =
@@ -984,7 +1000,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo2, seriesTokenUtxo = utxo4, quantity = BigInt(5))
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -1014,10 +1032,10 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val utxo3 = TransactionOutputAddress(0, 0, 3, dummyTxIdentifier)
     val utxo4 = TransactionOutputAddress(0, 0, 4, dummyTxIdentifier)
 
-    val gA = Event.GroupPolicy(label = "policyGA", registrationUtxo = utxo1)
-    val gB = Event.GroupPolicy(label = "policyGB", registrationUtxo = utxo2)
+    val gA = GroupPolicy(label = "policyGA", registrationUtxo = utxo1)
+    val gB = GroupPolicy(label = "policyGB", registrationUtxo = utxo2)
 
-    val sC = Event.SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
+    val sC = SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
 
     // inputs
     val inValue1_GA: Value =
@@ -1072,7 +1090,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo2, seriesTokenUtxo = utxo4, quantity = BigInt(10))
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -1100,9 +1120,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val utxo_abc = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
     val utxo_xyz = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
-    val g1 = Event.GroupPolicy(label = "policyG1", registrationUtxo = utxo_xyz)
+    val g1 = GroupPolicy(label = "policyG1", registrationUtxo = utxo_xyz)
 
-    val sC = Event.SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
+    val sC = SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
 
     // inputs
     val inValue1_abc: Value =
@@ -1133,7 +1153,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo_xyz, seriesTokenUtxo = utxo_abc, quantity = 1)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -1162,8 +1184,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val utxo_abc = TransactionOutputAddress(0, 0, 1, dummyTxIdentifier)
     val utxo_xyz = TransactionOutputAddress(0, 0, 2, dummyTxIdentifier)
 
-    val g1 = Event.GroupPolicy(label = "g1", registrationUtxo = utxo_xyz)
-    val s1 = Event.SeriesPolicy(label = "s1", registrationUtxo = utxo, tokenSupply = Some(5))
+    val g1 = GroupPolicy(label = "g1", registrationUtxo = utxo_xyz)
+    val s1 = SeriesPolicy(label = "s1", registrationUtxo = utxo, tokenSupply = Some(5))
 
     // inputs
     val inValue1_abc: Value =
@@ -1194,7 +1216,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo_xyz, seriesTokenUtxo = utxo_abc, quantity = 1)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -67,8 +67,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatement_1))
     val testTx =
       txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1, output_2, output_3), datum = datum)
 
@@ -120,8 +119,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     val mintingStatement_1 =
       Seq(AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_2, quantity = 10))
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatement_1))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2),
@@ -194,8 +192,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -261,8 +258,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatement_1))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2, output_3),
@@ -331,8 +327,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatement_1)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatement_1))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2),
@@ -396,8 +391,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -499,8 +493,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -554,8 +547,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1, output_2), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -619,8 +611,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1, output_2), datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -684,8 +675,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(
       inputs = List(input_1, input_2),
       outputs = List(output_1, output_2),
@@ -790,8 +780,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       quantity = BigInt(1)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = List(mintingStatement_1, mintingStatement_2))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event =
+      txFull.datum.event.copy(mintingStatements = List(mintingStatement_1, mintingStatement_2))
+    )
     val testTx = txFull.copy(
       inputs = List(input_abc, input_def, input_xyz, input_uvw),
       outputs = List(output_1, output_2, output_3, output_4, output_5),
@@ -895,8 +886,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       quantity = BigInt(1)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = List(mintingStatement_1, mintingStatement_2))
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event =
+      txFull.datum.event.copy(mintingStatements = List(mintingStatement_1, mintingStatement_2))
+    )
     val testTx = txFull.copy(
       inputs = List(input_abc, input_def, input_xyz, input_uvw),
       outputs = List(output_1, output_2, output_3, output_4, output_5),
@@ -1000,8 +992,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo2, seriesTokenUtxo = utxo4, quantity = BigInt(5))
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -1090,8 +1081,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo2, seriesTokenUtxo = utxo4, quantity = BigInt(10))
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -1153,8 +1143,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo_xyz, seriesTokenUtxo = utxo_abc, quantity = 1)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -1216,8 +1205,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       AssetMintingStatement(groupTokenUtxo = utxo_xyz, seriesTokenUtxo = utxo_abc, quantity = 1)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -3,10 +3,14 @@ package org.plasmalabs.sdk.validation
 import cats.Id
 import cats.implicits._
 import org.plasmalabs.sdk.MockHelpers
-import org.plasmalabs.sdk.models.Datum
-import org.plasmalabs.sdk.models.Event
-import org.plasmalabs.sdk.models.TransactionOutputAddress
-import org.plasmalabs.sdk.models.box.AssetMintingStatement
+import org.plasmalabs.sdk.models.{
+  AssetMintingStatement,
+  Datum,
+  Event,
+  GroupPolicy,
+  SeriesPolicy,
+  TransactionOutputAddress
+}
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.SpentTransactionOutput
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
@@ -28,8 +32,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
    * DuplicateInput because minting statements contains the same txoAddress
    */
   test("Invalid data-input case, input(0) + minted1 == output1, input and asset mining statements are duplicated") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
     val value_1_in =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = 1))
 
@@ -63,7 +67,9 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_1, quantity = 1)
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -81,8 +87,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
    * DuplicateInput because minting statements contains the same txoAddress
    */
   test("Invalid data-input case, input(0) + minted1 == output1, asset mining statements are duplicated") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = 1))
 
@@ -119,7 +125,9 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       )
     )
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -136,8 +144,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
    * DuplicateInput because minting statements contains the same txoAddress
    */
   test("Invalid data-input case, input(0) + minted1 == output1, asset mining statements are duplicated, case 2") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in =
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = 1))
 
@@ -175,7 +183,9 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
 
     val mintingStatements = List(mintingStatement_1, mintingStatement_2)
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -191,7 +201,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
   }
 
   test("Invalid data-input, minting a Group constructor Token") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val value_1_in =
       Value.defaultInstance.withLvl(Value.LVL(quantity = 1))
 
@@ -202,9 +212,11 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     val outputs = List(UnspentTransactionOutput(trivialLockAddress, value_1_out))
 
     // policies contains same referenced Utxos
-    val groupPolicies = List(Datum.GroupPolicy(groupPolicy), Datum.GroupPolicy(groupPolicy))
+    val groupPolicies = List(groupPolicy, groupPolicy)
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, groupPolicies = groupPolicies)
+    val policies = txFull.datum.event.policies.copy(groupPolicies = groupPolicies)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -216,8 +228,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
   }
 
   test("Invalid data-input, minting a Group constructor Token") {
-    val groupPolicy_A = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val groupPolicy_B = Event.GroupPolicy(label = "groupLabelB", registrationUtxo = txoAddress_1)
+    val groupPolicy_A = GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val groupPolicy_B = GroupPolicy(label = "groupLabelB", registrationUtxo = txoAddress_1)
     val value_1_in =
       Value.defaultInstance.withLvl(Value.LVL(quantity = 1))
 
@@ -234,9 +246,11 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     )
 
     // policies contains same referenced Utxos
-    val groupPolicies = List(Datum.GroupPolicy(groupPolicy_A), Datum.GroupPolicy(groupPolicy_B))
+    val groupPolicies = List(groupPolicy_A, groupPolicy_B)
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, groupPolicies = groupPolicies)
+    val policies = txFull.datum.event.policies.copy(groupPolicies = groupPolicies)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -252,7 +266,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
   }
 
   test("Invalid data-input, minting a Series constructor Token") {
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
     val value_1_in =
       Value.defaultInstance.withLvl(Value.LVL(quantity = 1))
 
@@ -262,9 +276,11 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
     val outputs = List(UnspentTransactionOutput(trivialLockAddress, value_1_out))
     // policies contains same referenced Utxos
-    val seriesPolicies = List(Datum.SeriesPolicy(seriesPolicy), Datum.SeriesPolicy(seriesPolicy))
+    val seriesPolicies = List(seriesPolicy, seriesPolicy)
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, seriesPolicies = seriesPolicies)
+    val policies = txFull.datum.event.policies.copy(seriesPolicies = seriesPolicies)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -276,8 +292,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
   }
 
   test("Invalid data-input, minting a Series constructor Token") {
-    val seriesPolicy_A = Event.SeriesPolicy(label = "seriesLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy_B = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val seriesPolicy_A = SeriesPolicy(label = "seriesLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy_B = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
 
     val value_1_in =
       Value.defaultInstance.withLvl(Value.LVL(quantity = 1))
@@ -294,9 +310,11 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_2_out)
     )
     // policies contains same referenced Utxos
-    val seriesPolicies = List(Datum.SeriesPolicy(seriesPolicy_A), Datum.SeriesPolicy(seriesPolicy_B))
+    val seriesPolicies = List(seriesPolicy_A, seriesPolicy_B)
 
-    val testTx = txFull.copy(inputs = inputs, outputs = outputs, seriesPolicies = seriesPolicies)
+    val policies = txFull.datum.event.policies.copy(seriesPolicies = seriesPolicies)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -308,8 +326,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
   }
 
   test("Invalid data-input, minting a Group and Series constructor Token") {
-    val g1 = Event.GroupPolicy(label = "g1", registrationUtxo = txoAddress_1)
-    val s1 = Event.SeriesPolicy(label = "s1", registrationUtxo = txoAddress_1)
+    val g1 = GroupPolicy(label = "g1", registrationUtxo = txoAddress_1)
+    val s1 = SeriesPolicy(label = "s1", registrationUtxo = txoAddress_1)
 
     val value_abc_in =
       Value.defaultInstance.withLvl(Value.LVL(quantity = 1))
@@ -326,11 +344,13 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       UnspentTransactionOutput(trivialLockAddress, value_2_out)
     )
     // policies contains same referenced Utxos
-    val groupPolicies = List(Datum.GroupPolicy(g1))
-    val seriesPolicies = List(Datum.SeriesPolicy(s1))
+    val groupPolicies = List(g1)
+    val seriesPolicies = List(s1)
 
+    val policies = txFull.datum.event.policies.copy(seriesPolicies = seriesPolicies, groupPolicies = groupPolicies)
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
     val testTx =
-      txFull.copy(inputs = inputs, outputs = outputs, groupPolicies = groupPolicies, seriesPolicies = seriesPolicies)
+      txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -67,8 +67,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_1, quantity = 1)
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -125,8 +124,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       )
     )
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -183,8 +181,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
 
     val mintingStatements = List(mintingStatement_1, mintingStatement_2)
 
-    val policies = txFull.datum.event.policies.copy(mintingStatements = mintingStatements)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(mintingStatements = mintingStatements))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -214,8 +211,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     // policies contains same referenced Utxos
     val groupPolicies = List(groupPolicy, groupPolicy)
 
-    val policies = txFull.datum.event.policies.copy(groupPolicies = groupPolicies)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(groupPolicies = groupPolicies))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -248,8 +244,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     // policies contains same referenced Utxos
     val groupPolicies = List(groupPolicy_A, groupPolicy_B)
 
-    val policies = txFull.datum.event.policies.copy(groupPolicies = groupPolicies)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(groupPolicies = groupPolicies))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -278,8 +273,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     // policies contains same referenced Utxos
     val seriesPolicies = List(seriesPolicy, seriesPolicy)
 
-    val policies = txFull.datum.event.policies.copy(seriesPolicies = seriesPolicies)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(seriesPolicies = seriesPolicies))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -312,8 +306,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     // policies contains same referenced Utxos
     val seriesPolicies = List(seriesPolicy_A, seriesPolicy_B)
 
-    val policies = txFull.datum.event.policies.copy(seriesPolicies = seriesPolicies)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum = txFull.datum.copy(event = txFull.datum.event.copy(seriesPolicies = seriesPolicies))
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
@@ -347,8 +340,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     val groupPolicies = List(g1)
     val seriesPolicies = List(s1)
 
-    val policies = txFull.datum.event.policies.copy(seriesPolicies = seriesPolicies, groupPolicies = groupPolicies)
-    val datum = txFull.datum.copy(event = txFull.datum.event.copy(policies = policies))
+    val datum =
+      txFull.datum.copy(event = txFull.datum.event.copy(seriesPolicies = seriesPolicies, groupPolicies = groupPolicies))
     val testTx =
       txFull.copy(inputs = inputs, outputs = outputs, datum = datum)
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterSpec.scala
@@ -7,7 +7,7 @@ import org.plasmalabs.sdk.constants.NetworkConstants.{MAIN_NETWORK_ID, TEST_NETW
 import org.plasmalabs.sdk.models.box.{Attestation, Challenge, Lock, Value}
 import org.plasmalabs.sdk.models.transaction.Schedule
 import com.google.protobuf.ByteString
-import quivr.models.{Int128, Proof, Proposition}
+import org.plasmalabs.quivr.models.{Int128, Proof, Proposition}
 import org.plasmalabs.quivr.api.{Proposer, Prover}
 
 class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
@@ -3,8 +3,7 @@ package org.plasmalabs.sdk.validation
 import cats.Id
 import cats.implicits._
 import org.plasmalabs.sdk.MockHelpers
-import org.plasmalabs.sdk.models.Event
-import org.plasmalabs.sdk.models.TransactionOutputAddress
+import org.plasmalabs.sdk.models.{Event, SeriesPolicy, TransactionOutputAddress}
 import org.plasmalabs.sdk.models.box.Value
 import org.plasmalabs.sdk.models.transaction.SpentTransactionOutput
 import org.plasmalabs.sdk.models.transaction.UnspentTransactionOutput
@@ -20,7 +19,7 @@ class TransactionSyntaxInterpreterTransferSeriesSpec extends munit.FunSuite with
   TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
 
   test("Valid data-input case, transfer a simple series ") {
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
 
     val value_1_in: Value =
       Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
@@ -56,7 +55,7 @@ class TransactionSyntaxInterpreterTransferSeriesSpec extends munit.FunSuite with
   }
 
   test("Valid data-input case 2, transfer a simple series ") {
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
 
     val value_1_in: Value =
       Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(2)))
@@ -96,7 +95,7 @@ class TransactionSyntaxInterpreterTransferSeriesSpec extends munit.FunSuite with
   }
 
   test("InValid data-input case 2, transfer a simple series ") {
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+    val seriesPolicy = SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
 
     val value_1_in: Value =
       Value.defaultInstance.withSeries(

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/wallet/CredentiallerInterpreterSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/wallet/CredentiallerInterpreterSpec.scala
@@ -33,13 +33,11 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
 
   test("prove: other fields on transaction are preserved") {
 
-    val iotxEvent = txFull.datum.event.withPolicies(
-      Event.IoTransaction
-        .Policies()
-        .withGroupPolicies(Seq(mockGroupPolicy))
-        .withSeriesPolicies(Seq(mockSeriesPolicy))
-        .withMintingStatements(Seq(AssetMintingStatement(dummyTxoAddress, dummyTxoAddress, quantity)))
-    )
+    val iotxEvent = txFull.datum.event
+      .withGroupPolicies(Seq(mockGroupPolicy))
+      .withSeriesPolicies(Seq(mockSeriesPolicy))
+      .withMintingStatements(Seq(AssetMintingStatement(dummyTxoAddress, dummyTxoAddress, quantity)))
+
     val testTx = txFull
       .withDatum(txFull.datum.copy(event = iotxEvent))
 

--- a/plasma-sdk/src/test/scala/org/plasmalabs/sdk/wallet/WalletApiSpec.scala
+++ b/plasma-sdk/src/test/scala/org/plasmalabs/sdk/wallet/WalletApiSpec.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.sdk.wallet
 
 import org.plasmalabs.sdk.{MockHelpers, MockWalletKeyApi}
-import quivr.models.KeyPair
+import org.plasmalabs.quivr.models.KeyPair
 import cats.arrow.FunctionK
 import org.plasmalabs.sdk.models.Indices
 import io.circe.syntax.EncoderOps

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val catsCoreVersion = "2.10.0"
     val circeVersion = "0.14.6"
-    val protobufSpecsVersion = "0.1.1"
+    val protobufSpecsVersion = "0.1.1+5-d27bacf6-SNAPSHOT" // TODO replace with final version
     val mUnitTeVersion = "0.7.29"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val catsCoreVersion = "2.10.0"
     val circeVersion = "0.14.6"
-    val protobufSpecsVersion = "0.1.1+6-b9d1b2a0-SNAPSHOT" // TODO replace with final version
+    val protobufSpecsVersion = "0.1.3"
     val mUnitTeVersion = "0.7.29"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val catsCoreVersion = "2.10.0"
     val circeVersion = "0.14.6"
-    val protobufSpecsVersion = "0.1.1+5-d27bacf6-SNAPSHOT" // TODO replace with final version
+    val protobufSpecsVersion = "0.1.1+6-b9d1b2a0-SNAPSHOT" // TODO replace with final version
     val mUnitTeVersion = "0.7.29"
   }
 

--- a/quivr4s/src/main/scala/org/plasmalabs/common/ParsableDataInterface.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/common/ParsableDataInterface.scala
@@ -1,6 +1,6 @@
 package org.plasmalabs.common
 
-import quivr.models.Data
+import org.plasmalabs.quivr.models.Data
 
 trait ParsableDataInterface {
   val data: Data

--- a/quivr4s/src/main/scala/org/plasmalabs/quivr/algebras/DigestVerifier.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/quivr/algebras/DigestVerifier.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.quivr.algebras
 
 import org.plasmalabs.common.ContextlessValidation
-import quivr.models.DigestVerification
+import org.plasmalabs.quivr.models.DigestVerification
 import org.plasmalabs.quivr.runtime.QuivrRuntimeError
 
 /** A trait that provides Digest verification for use in a Dynamic Context */

--- a/quivr4s/src/main/scala/org/plasmalabs/quivr/algebras/SignatureVerifier.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/quivr/algebras/SignatureVerifier.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.quivr.algebras
 
 import org.plasmalabs.common.ContextlessValidation
-import quivr.models.SignatureVerification
+import org.plasmalabs.quivr.models.SignatureVerification
 import org.plasmalabs.quivr.runtime.QuivrRuntimeError
 
 /** A trait that provides Signature verification for use in a Dynamic Context */

--- a/quivr4s/src/main/scala/org/plasmalabs/quivr/api/Proposer.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/quivr/api/Proposer.scala
@@ -3,11 +3,11 @@ package org.plasmalabs.quivr.api
 import cats.Applicative
 import cats.implicits._
 import com.google.protobuf.ByteString
-import quivr.models.Data
-import quivr.models.Digest
-import quivr.models.Int128
-import quivr.models.Proposition
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.Data
+import org.plasmalabs.quivr.models.Digest
+import org.plasmalabs.quivr.models.Int128
+import org.plasmalabs.quivr.models.Proposition
+import org.plasmalabs.quivr.models.VerificationKey
 
 // Proposers create Propositions from a tuple of arguments (or single argument) of type A.
 trait Proposer[F[_], A] {

--- a/quivr4s/src/main/scala/org/plasmalabs/quivr/api/Prover.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/quivr/api/Prover.scala
@@ -4,7 +4,7 @@ import cats.Applicative
 import cats.implicits._
 import org.plasmalabs.quivr.Tokens
 import com.google.protobuf.ByteString
-import quivr.models._
+import org.plasmalabs.quivr.models._
 
 import java.nio.charset.StandardCharsets
 import org.plasmalabs.crypto.hash.Blake2b256

--- a/quivr4s/src/main/scala/org/plasmalabs/quivr/api/Verifier.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/quivr/api/Verifier.scala
@@ -11,7 +11,7 @@ import org.plasmalabs.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
   UserProvidedInterfaceFailure
 }
 import org.plasmalabs.quivr.runtime.{DynamicContext, QuivrRuntimeError}
-import quivr.models._
+import org.plasmalabs.quivr.models._
 import java.nio.charset.StandardCharsets
 import org.plasmalabs.crypto.hash.Blake2b256
 

--- a/quivr4s/src/main/scala/org/plasmalabs/quivr/runtime/DynamicContext.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/quivr/runtime/DynamicContext.scala
@@ -4,7 +4,7 @@ import cats.Monad
 import cats.data.EitherT
 import org.plasmalabs.common.ParsableDataInterface
 import org.plasmalabs.quivr.runtime.QuivrRuntimeErrors.{ContextError, ValidationError}
-import quivr.models._
+import org.plasmalabs.quivr.models._
 import org.plasmalabs.quivr.algebras.{DigestVerifier, SignatureVerifier}
 
 /**

--- a/quivr4s/src/main/scala/org/plasmalabs/quivr/runtime/QuivrRuntimeError.scala
+++ b/quivr4s/src/main/scala/org/plasmalabs/quivr/runtime/QuivrRuntimeError.scala
@@ -1,7 +1,7 @@
 package org.plasmalabs.quivr.runtime
 
-import quivr.models.Proof
-import quivr.models.Proposition
+import org.plasmalabs.quivr.models.Proof
+import org.plasmalabs.quivr.models.Proposition
 
 /**
  * Errors resulting from evaluation of Quivr propositions / proofs

--- a/quivr4s/src/test/scala/org/plasmalabs/quivr/MockHelpers.scala
+++ b/quivr4s/src/test/scala/org/plasmalabs/quivr/MockHelpers.scala
@@ -7,7 +7,7 @@ import org.plasmalabs.common.ParsableDataInterface
 import org.plasmalabs.quivr.algebras.{DigestVerifier, SignatureVerifier}
 import org.plasmalabs.quivr.runtime.{DynamicContext, QuivrRuntimeError, QuivrRuntimeErrors}
 import com.google.protobuf.ByteString
-import quivr.models._
+import org.plasmalabs.quivr.models._
 import org.plasmalabs.crypto.hash.Blake2b256
 
 trait MockHelpers {

--- a/quivr4s/src/test/scala/org/plasmalabs/quivr/QuivrAtomicOpTests.scala
+++ b/quivr4s/src/test/scala/org/plasmalabs/quivr/QuivrAtomicOpTests.scala
@@ -4,8 +4,8 @@ import cats.{Id, Monad}
 import org.plasmalabs.sdk.models.Datum
 import org.plasmalabs.quivr.runtime.QuivrRuntimeErrors
 import com.google.protobuf.ByteString
-import quivr.models.VerificationKey._
-import quivr.models._
+import org.plasmalabs.quivr.models.VerificationKey._
+import org.plasmalabs.quivr.models._
 import org.plasmalabs.crypto.hash.Blake2b256
 
 /**

--- a/quivr4s/src/test/scala/org/plasmalabs/quivr/QuivrCompositeOpsTests.scala
+++ b/quivr4s/src/test/scala/org/plasmalabs/quivr/QuivrCompositeOpsTests.scala
@@ -2,8 +2,8 @@ package org.plasmalabs.quivr
 
 import cats.{Id, Monad}
 import com.google.protobuf.ByteString
-import quivr.models.VerificationKey._
-import quivr.models._
+import org.plasmalabs.quivr.models.VerificationKey._
+import org.plasmalabs.quivr.models._
 import runtime.QuivrRuntimeErrors
 
 /**

--- a/quivr4s/src/test/scala/org/plasmalabs/quivr/generators/ModelGenerators.scala
+++ b/quivr4s/src/test/scala/org/plasmalabs/quivr/generators/ModelGenerators.scala
@@ -2,7 +2,7 @@ package org.plasmalabs.quivr.generators
 
 import com.google.protobuf.ByteString
 import org.scalacheck.{Arbitrary, Gen}
-import quivr.models.Digest
+import org.plasmalabs.quivr.models.Digest
 
 trait ModelGenerators {
 

--- a/service-kit/src/main/scala/org/plasmalabs/sdk/servicekit/EasyApi.scala
+++ b/service-kit/src/main/scala/org/plasmalabs/sdk/servicekit/EasyApi.scala
@@ -6,7 +6,7 @@ import cats.effect.Async
 import cats.implicits.{catsSyntaxApplicativeError, catsSyntaxEitherId, toBifunctorOps, toFlatMapOps, toFunctorOps}
 import org.plasmalabs.sdk.models.transaction.IoTransaction
 import org.plasmalabs.sdk.models.{Datum, Event, LockAddress, TransactionId}
-import quivr.models.VerificationKey
+import org.plasmalabs.quivr.models.VerificationKey
 import org.plasmalabs.sdk.Context
 import org.plasmalabs.sdk.builders.TransactionBuilderApi
 import org.plasmalabs.sdk.builders.TransactionBuilderApi.implicits.lockAddressOps

--- a/service-kit/src/main/scala/org/plasmalabs/sdk/servicekit/WalletStateApi.scala
+++ b/service-kit/src/main/scala/org/plasmalabs/sdk/servicekit/WalletStateApi.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import io.circe.parser._
 import io.circe.syntax.EncoderOps
-import quivr.models.{KeyPair, Preimage, Proposition, VerificationKey}
+import org.plasmalabs.quivr.models.{KeyPair, Preimage, Proposition, VerificationKey}
 import org.plasmalabs.sdk.builders.TransactionBuilderApi
 import org.plasmalabs.sdk.builders.locks.{LockTemplate, PropositionTemplate}
 import org.plasmalabs.sdk.codecs.AddressCodecs

--- a/service-kit/src/test/scala/org/plasmalabs/sdk/servicekit/BaseSpec.scala
+++ b/service-kit/src/test/scala/org/plasmalabs/sdk/servicekit/BaseSpec.scala
@@ -14,7 +14,7 @@ import org.plasmalabs.sdk.constants.NetworkConstants._
 import org.plasmalabs.sdk.dataApi.WalletStateAlgebra
 import org.plasmalabs.sdk.syntax.cryptoToPbKeyPair
 import org.plasmalabs.crypto.generation.KeyInitializer.Instances.extendedEd25519Initializer
-import quivr.models
+import org.plasmalabs.quivr.models
 
 import java.sql.Connection
 import org.plasmalabs.crypto.signing.{ExtendedEd25519, KeyPair}

--- a/service-kit/src/test/scala/org/plasmalabs/sdk/servicekit/WalletStateApiSpec.scala
+++ b/service-kit/src/test/scala/org/plasmalabs/sdk/servicekit/WalletStateApiSpec.scala
@@ -11,7 +11,7 @@ import org.plasmalabs.sdk.models.box.Lock
 import org.plasmalabs.sdk.utils.Encoding
 import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
-import quivr.models.{Digest, Preimage, Proposition}
+import org.plasmalabs.quivr.models.{Digest, Preimage, Proposition}
 
 class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
 


### PR DESCRIPTION
## Purpose
Refactor statements and policies into datum.

If new protobuf-specs models are accepted, these changes are required on the sdk.

## Depends on
- https://github.com/PlasmaLaboratories/plasma-protobuf-specs/pull/11


## Testing
-preparePF
## Tickets
BN-1645

