### PR TITLE
Update dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val catsCoreVersion = "2.12.0"
     val circeVersion = "0.14.10"
-    val protobufSpecsVersion = "0.1.1"
+    val protobufSpecsVersion = "0.1.2"
   }
 
   val catsSlf4j: ModuleID =
@@ -21,7 +21,7 @@ object Dependencies {
   )
 
   val scalacheck: Seq[ModuleID] = Seq(
-    "org.scalacheck"    %% "scalacheck"      % "1.17.1",
+    "org.scalacheck"    %% "scalacheck"      % "1.18.1",
     "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0"
   )
 
@@ -43,7 +43,6 @@ object Dependencies {
 
   val cats: Seq[ModuleID] = Seq(
     "org.typelevel" %% "cats-core"   % catsCoreVersion,
-    "org.typelevel" %% "mouse"       % "1.2.4",
     "org.typelevel" %% "cats-free"   % catsCoreVersion,
     "org.typelevel" %% "cats-effect" % "3.5.5"
   )
@@ -53,7 +52,7 @@ object Dependencies {
   )
 
   val sqlite: Seq[ModuleID] = Seq(
-    "org.xerial" % "sqlite-jdbc" % "3.45.3.0"
+    "org.xerial" % "sqlite-jdbc" % "3.47.0.0"
   )
 
   val grpcNetty = "io.grpc" % "grpc-netty" % "1.68.1"

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -4,7 +4,7 @@
 // This plugin enables semantic information to be produced by sbt.
 // It also adds support for debugging using the Debug Adapter Protocol
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-addSbtPlugin("org.scalameta" % "sbt-metals" % "1.3.5+206-23423ed1-SNAPSHOT")
+addSbtPlugin("org.scalameta" % "sbt-metals" % "1.4.0")
 
 // This plugin adds the BSP debug capability to sbt server.
 

--- a/project/site.sbt
+++ b/project/site.sbt
@@ -1,10 +1,10 @@
 
 Seq(
   "com.eed3si9n"            % "sbt-assembly"              % "2.3.0",
-  "org.scoverage"           % "sbt-scoverage"             % "2.2.1",
+  "org.scoverage"           % "sbt-scoverage"             % "2.2.2",
   "com.github.sbt"          % "sbt-release"               % "1.4.0",
   "org.scalameta"           % "sbt-scalafmt"              % "2.5.2",
-  "ch.epfl.scala"           % "sbt-scalafix"              % "0.12.1",
+  "ch.epfl.scala"           % "sbt-scalafix"              % "0.13.0",
   "com.eed3si9n"            % "sbt-buildinfo"             % "0.13.1",
   "com.github.sbt"          % "sbt-ci-release"            % "1.9.0",
   "net.bzzt"                % "sbt-reproducible-builds"   % "0.32",


### PR DESCRIPTION
## Purpose
Update dependencies

📦 [ch.epfl.scala:sbt-scalafix](https://github.com/scalacenter/sbt-scalafix) from 0.12.1 to 0.13.0
📦 [org.plasmalabs:protobuf-fs2](https://github.com/PlasmaLaboratories/plasma-protobuf-specs) from 0.1.1 to 0.1.2
📦 [org.scalacheck:scalacheck](https://github.com/typelevel/scalacheck) from 1.17.1 to 1.18.1
📦 [org.scalameta:sbt-metals](https://github.com/scalameta/metals) from 1.3.5+206-23423ed1-SNAPSHOT to 1.4.0
📦 [org.scoverage:sbt-scoverage](https://github.com/scoverage/sbt-scoverage) from 2.0.12 to 2.2.2

📦 [org.xerial:sqlite-jdbc](https://github.com/xerial/sqlite-jdbc) from 3.45.3.0 to 3.47.0.0


remove dependencies
📦 [org.typelevel:mouse](https://github.com/typelevel/mouse) from 1.2.4
