### PR TITLE
Update build.sbt

### DIFF
--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -41,8 +41,6 @@ jobs:
     - uses: sbt/setup-sbt@v1
       with:
         sbt-runner-version: 1.9.9
-    - name: Clean, delete step later
-      run: sbt +clean
     - name: Compile and Test
       run: sbt checkPR
     - name: Upload Test Results

--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -41,6 +41,8 @@ jobs:
     - uses: sbt/setup-sbt@v1
       with:
         sbt-runner-version: 1.9.9
+    - name: Clean, delete step later
+      run: sbt +clean
     - name: Compile and Test
       run: sbt checkPR
     - name: Upload Test Results

--- a/build.sbt
+++ b/build.sbt
@@ -179,6 +179,6 @@ lazy val plasma = project
     quivr4s
   )
 
-addCommandAlias("checkPR", s"; +clean; scalafixAll --check; scalafmtCheckAll; coverage; +test; coverageReport")
+addCommandAlias("checkPR", s"; clean; scalafixAll --check; scalafmtCheckAll; coverage; +test; coverageReport")
 addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; unidoc")
 addCommandAlias("checkPRTestQuick", s"; scalafixAll --check; scalafmtCheckAll; +testQuick")

--- a/build.sbt
+++ b/build.sbt
@@ -179,6 +179,6 @@ lazy val plasma = project
     quivr4s
   )
 
-addCommandAlias("checkPR", s"; clean; scalafixAll --check; scalafmtCheckAll; coverage; +test; coverageReport")
+addCommandAlias("checkPR", s"; +clean; scalafixAll --check; scalafmtCheckAll; coverage; +test; coverageReport")
 addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; unidoc")
 addCommandAlias("checkPRTestQuick", s"; scalafixAll --check; scalafmtCheckAll; +testQuick")

--- a/build.sbt
+++ b/build.sbt
@@ -179,6 +179,6 @@ lazy val plasma = project
     quivr4s
   )
 
-addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; coverage; +test; coverageReport")
+addCommandAlias("checkPR", s"; clean; scalafixAll --check; scalafmtCheckAll; coverage; +test; coverageReport")
 addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; unidoc")
 addCommandAlias("checkPRTestQuick", s"; scalafixAll --check; scalafmtCheckAll; +testQuick")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val scala213 = "2.13.15"
-val scala33 = "3.5.2"
+val scala33 = "3.3.4"
 
 inThisBuild(
   List(

--- a/crypto/src/test/scala/org/plasmalabs/crypto/generation/KeyInitializerSpec.scala
+++ b/crypto/src/test/scala/org/plasmalabs/crypto/generation/KeyInitializerSpec.scala
@@ -33,7 +33,7 @@ class KeyInitializerSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks
     for {
       pair <- EntropyTestVectorHelper.mnemonicStringAndSize(c)
       (mnemonicString, size) = pair
-      password               <- c.downField("password").as[Option[String]]
+      password <- c.downField("password").as[Option[String]]
     } yield SpecInputs(mnemonicString, size, password)
 
   implicit val outputsDecoder: Decoder[SpecOutputs] = (c: HCursor) =>

--- a/crypto/src/test/scala/org/plasmalabs/crypto/generation/KeyInitializerSpec.scala
+++ b/crypto/src/test/scala/org/plasmalabs/crypto/generation/KeyInitializerSpec.scala
@@ -31,7 +31,8 @@ class KeyInitializerSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks
 
   implicit val inputsDecoder: Decoder[SpecInputs] = (c: HCursor) =>
     for {
-      (mnemonicString, size) <- EntropyTestVectorHelper.mnemonicStringAndSize(c)
+      pair <- EntropyTestVectorHelper.mnemonicStringAndSize(c)
+      (mnemonicString, size) = pair
       password               <- c.downField("password").as[Option[String]]
     } yield SpecInputs(mnemonicString, size, password)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val catsCoreVersion = "2.12.0"
     val circeVersion = "0.14.10"
-    val protobufSpecsVersion = "0.1.4"
+    val protobufSpecsVersion = "0.1.5"
   }
 
   val catsSlf4j: ModuleID =


### PR DESCRIPTION
 The current recommendation for libraries is to use the latest LTS release (see https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html) unless we are using some new feature of the latest version. Should we go back to the latest LTS release (Scala 3.3.4 LTS)
